### PR TITLE
docs: restore corresponding-author markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 [Jiajie Su](https://scholar.google.com/citations?hl=zh-CN&user=tn09CCIAAAAJ&view_op=list_works&sortby=pubdate)<sup>1</sup>, 
 [Pengyang Zhou](https://scholar.google.com/citations?hl=zh-CN&user=3LnDqE4AAAAJ&view_op=list_works&sortby=pubdate)<sup>1</sup>, 
 [Xiang Chen](https://scholar.google.com/citations?user=ZMdsjDUAAAAJ&hl=zh-CN&oi=sra)<sup>1</sup>, 
-[Xiaolin Zheng](https://person.zju.edu.cn/xlzheng#0)<sup>1,*</sup>, 
-[Feng Tian](https://www.xjtu.edu.cn/jsnr.jsp?wbtreeid=1632&wbwbxjtuteacherid=1473)<sup>2,*</sup>,
+[Xiaolin Zheng](https://person.zju.edu.cn/xlzheng#0)<sup>1,&#42;</sup>, 
+[Feng Tian](https://www.xjtu.edu.cn/jsnr.jsp?wbtreeid=1632&wbwbxjtuteacherid=1473)<sup>2,&#42;</sup>,
 [Chaochao Chen](https://person.zju.edu.cn/zjuccc)<sup>1</sup>
 
 <sup>1</sup>[Zhejiang University](https://www.zju.edu.cn/), 
 <sup>2</sup>[Xi'an Jiaotong University](https://www.xjtu.edu.cn/), 
 
-<sup>*</sup>Corresponding Author
+<sup>&#42;</sup> Corresponding Authors
 
 </div>
 


### PR DESCRIPTION
## Summary

- replace raw asterisks inside the author superscripts with the HTML entity `&#42;` so GitHub renders them reliably
- restore the corresponding-author markers for Xiaolin Zheng and Feng Tian
- change the legend to `Corresponding Authors` because two authors are marked

## Result

- Xiaolin Zheng: affiliation `1` plus `*`
- Feng Tian: affiliation `2` plus `*`
- legend: `* Corresponding Authors`