### PR TITLE
Redesign GitHub Pages as an academic project website

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,359 +3,262 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="theme-color" content="#07111f">
-  <meta name="description" content="PGPO preserves the relational structure of item side information while protecting LLM-enhanced recommenders against embedding inversion attacks.">
-  <meta name="keywords" content="PGPO, privacy-preserving recommendation, LLM-enhanced recommendation, relational fidelity, embedding inversion, GRPO">
-  <meta name="author" content="Shengxiang Lin, Jiajie Su, Pengyang Zhou, Xiang Chen, Xiaolin Zheng, Feng Tian, Chaochao Chen">
-
-  <meta property="og:type" content="article">
-  <meta property="og:title" content="PGPO: Prototype-Guided Progressive Obfuscation">
-  <meta property="og:description" content="Privacy-preserving LLM-enhanced recommendation through relational-fidelity obfuscation.">
+  <meta name="theme-color" content="#f7f8fc">
+  <meta name="description" content="PGPO learns topology-aware obfuscation for privacy-preserving LLM-enhanced recommendation.">
+  <meta property="og:title" content="PGPO — Prototype-Guided Progressive Obfuscation">
+  <meta property="og:description" content="Preserving relational fidelity for private LLM-enhanced recommendation.">
+  <meta property="og:type" content="website">
   <meta property="og:url" content="https://shengxiang-lin.github.io/PGPO/">
-  <meta property="og:image" content="https://shengxiang-lin.github.io/PGPO/assets/framework.webp">
-  <meta property="og:image:alt" content="Overview of the PGPO framework">
-  <meta name="twitter:card" content="summary_large_image">
-
-  <meta name="citation_title" content="PGPO: Prototype-Guided Progressive Obfuscation for Privacy-Preserving LLM-Enhanced Recommendation">
-  <meta name="citation_author" content="Lin, Shengxiang">
-  <meta name="citation_author" content="Su, Jiajie">
-  <meta name="citation_author" content="Zhou, Pengyang">
-  <meta name="citation_author" content="Chen, Xiang">
-  <meta name="citation_author" content="Zheng, Xiaolin">
-  <meta name="citation_author" content="Tian, Feng">
-  <meta name="citation_author" content="Chen, Chaochao">
-  <meta name="citation_conference_title" content="EMNLP 2026">
-  <meta name="citation_publication_date" content="2026">
-
-  <link rel="canonical" href="https://shengxiang-lin.github.io/PGPO/">
+  <title>PGPO — Privacy-Preserving LLM-Enhanced Recommendation</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&amp;display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=DM+Sans:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
-  <title>PGPO | Privacy-Preserving LLM-Enhanced Recommendation</title>
-
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "ScholarlyArticle",
-    "headline": "PGPO: Prototype-Guided Progressive Obfuscation for Privacy-Preserving LLM-Enhanced Recommendation",
-    "author": [
-      {"@type": "Person", "name": "Shengxiang Lin"},
-      {"@type": "Person", "name": "Jiajie Su"},
-      {"@type": "Person", "name": "Pengyang Zhou"},
-      {"@type": "Person", "name": "Xiang Chen"},
-      {"@type": "Person", "name": "Xiaolin Zheng"},
-      {"@type": "Person", "name": "Feng Tian"},
-      {"@type": "Person", "name": "Chaochao Chen"}
-    ],
-    "datePublished": "2026",
-    "isAccessibleForFree": true,
-    "url": "https://shengxiang-lin.github.io/PGPO/",
-    "codeRepository": "https://github.com/Shengxiang-Lin/PGPO"
-  }
-  </script>
 </head>
 <body>
-  <a class="skip-link" href="#main">Skip to content</a>
+  <a class="skip-link" href="#content">Skip to content</a>
 
   <header class="hero" id="top">
-    <div class="hero-grid" aria-hidden="true"></div>
-    <svg class="hero-network" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
-      <g class="network-lines">
-        <path d="M60 560L245 445L420 520L595 380L760 465L940 300L1130 390L1325 230L1540 340"/>
-        <path d="M25 735L220 625L420 690L595 565L785 650L970 515L1170 610L1370 485L1580 570"/>
-        <path d="M245 445L220 625M420 520L420 690M595 380L595 565M760 465L785 650M940 300L970 515M1130 390L1170 610M1325 230L1370 485"/>
-      </g>
-      <g class="network-nodes">
-        <circle cx="245" cy="445" r="13"/><circle cx="420" cy="520" r="9"/><circle cx="595" cy="380" r="17"/>
-        <circle cx="760" cy="465" r="10"/><circle cx="940" cy="300" r="15"/><circle cx="1130" cy="390" r="10"/>
-        <circle cx="1325" cy="230" r="18"/><circle cx="220" cy="625" r="8"/><circle cx="420" cy="690" r="14"/>
-        <circle cx="595" cy="565" r="8"/><circle cx="785" cy="650" r="16"/><circle cx="970" cy="515" r="9"/>
-        <circle cx="1170" cy="610" r="14"/><circle cx="1370" cy="485" r="9"/>
-      </g>
-    </svg>
-
-    <nav class="nav shell" aria-label="Primary navigation">
-      <a class="brand" href="#top" aria-label="PGPO home">
-        <span class="brand-mark" aria-hidden="true">P</span>
-        <span>PGPO</span>
-      </a>
-      <div class="nav-links">
-        <a href="#overview">Overview</a>
-        <a href="#method">Method</a>
-        <a href="#results">Results</a>
-        <a href="#citation">Citation</a>
-      </div>
+    <nav class="paper-nav" aria-label="Page sections">
+      <a href="#abstract">Abstract</a>
+      <a href="#method">Method</a>
+      <a href="#results">Results</a>
+      <a href="#citation">Citation</a>
     </nav>
 
-    <div class="hero-content shell">
-      <div class="venue-pill"><span></span> EMNLP 2026 · Main Conference</div>
-      <h1><span class="title-accent">PGPO:</span> Prototype-Guided Progressive Obfuscation for Privacy-Preserving LLM-Enhanced Recommendation</h1>
-      <p class="hero-kicker">Shift semantics. Preserve relations. Protect recommendations.</p>
+    <div class="hero-inner">
+      <p class="venue">EMNLP 2026 <span aria-hidden="true">·</span> Main Conference</p>
+
+      <h1><span>PGPO:</span> Prototype-Guided Progressive Obfuscation for Privacy-Preserving LLM-Enhanced Recommendation</h1>
 
       <div class="authors" aria-label="Authors">
-        <a href="https://shengxiang-lin.github.io/" target="_blank" rel="noopener">Shengxiang Lin<sup>1</sup></a>
-        <a href="https://scholar.google.com/citations?hl=zh-CN&amp;user=tn09CCIAAAAJ&amp;view_op=list_works&amp;sortby=pubdate" target="_blank" rel="noopener">Jiajie Su<sup>1</sup></a>
-        <a href="https://scholar.google.com/citations?hl=zh-CN&amp;user=3LnDqE4AAAAJ&amp;view_op=list_works&amp;sortby=pubdate" target="_blank" rel="noopener">Pengyang Zhou<sup>1</sup></a>
-        <a href="https://scholar.google.com/citations?user=ZMdsjDUAAAAJ&amp;hl=zh-CN&amp;oi=sra" target="_blank" rel="noopener">Xiang Chen<sup>1</sup></a>
-        <a href="https://person.zju.edu.cn/xlzheng#0" target="_blank" rel="noopener">Xiaolin Zheng<sup>1,*</sup></a>
-        <a href="https://www.xjtu.edu.cn/jsnr.jsp?wbtreeid=1632&amp;wbwbxjtuteacherid=1473" target="_blank" rel="noopener">Feng Tian<sup>2,*</sup></a>
-        <a href="https://person.zju.edu.cn/zjuccc" target="_blank" rel="noopener">Chaochao Chen<sup>1</sup></a>
+        <span><a href="https://Shengxiang-Lin.github.io/">Shengxiang Lin</a><sup>1</sup>,</span>
+        <span><a href="https://scholar.google.com/citations?hl=zh-CN&amp;user=tn09CCIAAAAJ&amp;view_op=list_works&amp;sortby=pubdate">Jiajie Su</a><sup>1</sup>,</span>
+        <span><a href="https://scholar.google.com/citations?hl=zh-CN&amp;user=3LnDqE4AAAAJ&amp;view_op=list_works&amp;sortby=pubdate">Pengyang Zhou</a><sup>1</sup>,</span>
+        <span><a href="https://scholar.google.com/citations?user=ZMdsjDUAAAAJ&amp;hl=zh-CN&amp;oi=sra">Xiang Chen</a><sup>1</sup>,</span>
+        <span><a href="https://person.zju.edu.cn/xlzheng#0">Xiaolin Zheng</a><sup>1,&#42;</sup>,</span>
+        <span><a href="https://www.xjtu.edu.cn/jsnr.jsp?wbtreeid=1632&amp;wbwbxjtuteacherid=1473">Feng Tian</a><sup>2,&#42;</sup>,</span>
+        <span><a href="https://person.zju.edu.cn/zjuccc">Chaochao Chen</a><sup>1</sup></span>
       </div>
 
       <div class="affiliations">
         <span><sup>1</sup> Zhejiang University</span>
         <span><sup>2</sup> Xi'an Jiaotong University</span>
-        <span class="corresponding"><sup>*</sup> Corresponding Authors</span>
+        <span><sup>&#42;</sup> Corresponding authors</span>
       </div>
 
-      <div class="hero-actions">
-        <a class="button button-primary" href="https://github.com/Shengxiang-Lin/PGPO" target="_blank" rel="noopener">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.87c-2.78.6-3.37-1.18-3.37-1.18-.45-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.9 1.53 2.35 1.09 2.92.83.09-.65.35-1.09.64-1.34-2.22-.25-4.56-1.11-4.56-4.94 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.64 0 0 .84-.27 2.75 1.02A9.57 9.57 0 0 1 12 6.82a9.6 9.6 0 0 1 2.5.34c1.91-1.29 2.75-1.02 2.75-1.02.55 1.37.2 2.39.1 2.64.64.7 1.03 1.59 1.03 2.68 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.86v2.76c0 .27.18.58.69.48A10 10 0 0 0 12 2Z"/></svg>
-          Code
+      <div class="hero-actions" aria-label="Paper resources">
+        <a class="button button-primary" href="https://github.com/Shengxiang-Lin/PGPO">
+          <span>Paper</span><small>arXiv coming soon</small>
         </a>
-        <a class="button button-light" href="https://github.com/Shengxiang-Lin/PGPO" target="_blank" rel="noopener">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 2h8l4 4v16H6V2Zm8 1.5V7h3.5M9 11h6M9 15h6M9 19h4"/></svg>
-          Paper <small>arXiv soon</small>
-        </a>
-        <a class="button button-light" href="https://github.com/Shengxiang-Lin/PGPO/tree/main/evaluate" target="_blank" rel="noopener">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 19V9m5 10V5m5 14v-7m5 7V3"/></svg>
-          Evaluation
-        </a>
+        <a class="button" href="https://github.com/Shengxiang-Lin/PGPO">Code <span aria-hidden="true">↗</span></a>
+        <a class="button" href="https://github.com/Shengxiang-Lin/PGPO/tree/main/evaluate">Evaluation <span aria-hidden="true">↗</span></a>
       </div>
     </div>
-
-    <a class="scroll-cue" href="#overview" aria-label="Scroll to overview"><span></span></a>
   </header>
 
-  <main id="main">
-    <section class="section section-intro" id="overview">
-      <div class="shell narrow">
-        <div class="eyebrow">The central idea</div>
-        <h2>Privacy needs a different kind of fidelity.</h2>
-        <p class="lead">LLM-enhanced recommenders benefit from semantic item embeddings, but those embeddings can expose sensitive textual attributes through inversion attacks. PGPO moves beyond preserving literal meaning: it protects individual content while retaining the <strong>relative semantic topology</strong> that recommendation models actually need.</p>
-
-        <div class="definition-card">
-          <div class="definition-icon" aria-hidden="true">
-            <svg viewBox="0 0 64 64"><circle cx="14" cy="32" r="7"/><circle cx="34" cy="15" r="7"/><circle cx="49" cy="39" r="7"/><path d="M20 27l8-7m11 1l7 12M21 34l21 4"/></svg>
-          </div>
-          <div>
-            <span>Relational fidelity</span>
-            <p>Induce sufficient semantic shift for privacy while preserving local neighborhood order and inter-item relationships for utility.</p>
-          </div>
-        </div>
-      </div>
+  <main id="content">
+    <section class="section section-narrow" id="abstract">
+      <p class="section-kicker">Abstract</p>
+      <h2>Protect what an embedding reveals.<br>Preserve what recommendation needs.</h2>
+      <p class="abstract-text">LLM-enhanced recommender systems encode item side information into semantic embeddings, but these embeddings may leak sensitive textual attributes through inversion attacks. Existing input-side defenses rely on trusted collection or local token perturbation, often disrupting the inter-item semantic topology needed for recommendation. To address it, we introduce <em>relational fidelity</em> as the key objective, requiring semantic shift for privacy while preserving relative item relations for utility. Based on this principle, we propose prototype-guided progressive obfuscation (PGPO), which learns topology-aware obfuscation anchors for high-influence prototype words and propagates them through a static semantic graph. PGPO is optimized with GRPO using individual dissimilarity, structural consistency, and semantic constraint rewards. Experiments on two benchmarks show strong inversion defense with near-upper-bound recommendation performance.</p>
     </section>
 
-    <section class="section section-tint" id="motivation">
-      <div class="shell split">
-        <div class="split-copy">
-          <div class="eyebrow">Motivation</div>
-          <h2>Hide the text, not the structure.</h2>
-          <p>Semantic embeddings can make item side information useful to downstream recommenders, yet the same representations may reveal their sources. Conventional word-level perturbations treat items independently and can shatter the semantic neighborhoods that connect cold and popular items.</p>
-          <p>PGPO instead reconstructs a usable semantic skeleton: variants move away from their source words, while their relative relationships remain available to the recommender.</p>
-          <ul class="check-list">
-            <li>Input-side protection before third-party LLM processing</li>
-            <li>Topology-aware rather than token-isolated obfuscation</li>
-            <li>Explicit privacy-utility optimization under aligned perturbation</li>
-          </ul>
-        </div>
-        <figure class="media-card motivation-card">
-          <img src="assets/motivation.webp" alt="Motivation for relational-fidelity obfuscation" loading="lazy">
-          <figcaption>Relational-fidelity obfuscation shifts exposed attributes while preserving the item relations used for recommendation.</figcaption>
-        </figure>
-      </div>
-    </section>
-
-    <section class="section" id="method">
-      <div class="shell">
-        <div class="section-heading">
-          <div class="eyebrow">Method</div>
-          <h2>Prototype-guided, progressive, and topology-aware.</h2>
-          <p>PGPO concentrates optimization on structurally influential prototypes, then propagates their learned mappings from the semantic core to the full vocabulary.</p>
-        </div>
-
-        <div class="steps" aria-label="PGPO stages">
-          <article class="step">
-            <span class="step-number">01</span>
-            <h3>Build the graph</h3>
-            <p>Identify high-influence prototype words and precompute a static vocabulary-level semantic neighbor graph.</p>
-          </article>
-          <article class="step">
-            <span class="step-number">02</span>
-            <h3>Explore anchors</h3>
-            <p>Use GRPO to learn privacy-preserving prototype variants that form stable structural anchors.</p>
-          </article>
-          <article class="step">
-            <span class="step-number">03</span>
-            <h3>Expand outward</h3>
-            <p>Condition on finalized neighbors and progressively propagate the anchored structure to non-prototype words.</p>
-          </article>
-        </div>
-
-        <figure class="framework media-card">
-          <img src="assets/framework.webp" alt="Three-stage PGPO framework and reward functions" loading="lazy">
-          <figcaption>PGPO couples prototype-aware graph construction, GRPO-based variant exploration, and anchor-oriented graph expansion with a global shared cache.</figcaption>
-        </figure>
-      </div>
-    </section>
-
-    <section class="section section-dark" id="rewards">
-      <div class="shell">
-        <div class="section-heading light">
-          <div class="eyebrow">Reward-guided optimization</div>
-          <h2>Three signals, one privacy-utility objective.</h2>
-        </div>
-        <div class="reward-grid">
-          <article class="reward-card coral">
-            <span>R<sub>dis</sub></span>
-            <h3>Individual dissimilarity</h3>
-            <p>Push each generated variant away from its source embedding to weaken local reconstruction and re-identification.</p>
-          </article>
-          <article class="reward-card blue">
-            <span>R<sub>str</sub></span>
-            <h3>Structural consistency</h3>
-            <p>Preserve neighborhood rankings and pairwise similarity distributions across original and obfuscated spaces.</p>
-          </article>
-          <article class="reward-card gold">
-            <span>R<sub>con</sub></span>
-            <h3>Semantic constraint</h3>
-            <p>Keep variants inside category-specific manifolds, preventing invalid or degenerate shortcuts during exploration.</p>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section class="section section-results" id="results">
-      <div class="shell">
-        <div class="section-heading">
-          <div class="eyebrow">Results</div>
-          <h2>Strong privacy with near-upper-bound recommendation utility.</h2>
-          <p>Experiments on MovieLens-1M and Amazon-Book cover variant quality, six downstream recommenders, embedding inversion, and a white-box Replay-MLE attacker.</p>
-        </div>
-
-        <div class="metric-grid">
-          <article class="metric-card">
-            <div class="metric-value">0.1981</div>
-            <div class="metric-label">MovieLens-1M Spearman</div>
-            <p>Highest local structural correlation among compared obfuscation methods.</p>
-          </article>
-          <article class="metric-card">
-            <div class="metric-value">0.1808</div>
-            <div class="metric-label">Amazon-Book Spearman</div>
-            <p>Maintains relational topology under strong semantic displacement.</p>
-          </article>
-          <article class="metric-card">
-            <div class="metric-value">&lt; 2%</div>
-            <div class="metric-label">Typical utility drop</div>
-            <p>Versus raw descriptions for traditional collaborative filtering models.</p>
-          </article>
-          <article class="metric-card">
-            <div class="metric-value">&gt; 50%</div>
-            <div class="metric-label">Attack-success reduction</div>
-            <p>All evaluated obfuscation methods substantially reduce inversion success; PGPO retains stronger utility.</p>
-          </article>
-        </div>
-
-        <div class="embedding-grid">
-          <figure class="media-card">
-            <img src="assets/tsne-movielens.webp" alt="T-SNE visualization of MovieLens-1M item embeddings" loading="lazy">
-            <figcaption>MovieLens-1M item embeddings</figcaption>
-          </figure>
-          <figure class="media-card">
-            <img src="assets/tsne-amazon.webp" alt="T-SNE visualization of Amazon-Book item embeddings" loading="lazy">
-            <figcaption>Amazon-Book item embeddings</figcaption>
-          </figure>
-        </div>
-
-        <p class="results-note">The visual separation of method-specific embeddings shows strong semantic displacement. PGPO's recommendation performance indicates that the relational structure needed downstream remains usable.</p>
-      </div>
-    </section>
-
-    <section class="section section-tint" id="resources">
-      <div class="shell resource-shell">
+    <section class="section ruled" id="overview">
+      <div class="section-heading split-heading">
         <div>
-          <div class="eyebrow">Open-source pipeline</div>
-          <h2>From semantic graph construction to white-box evaluation.</h2>
-          <p>The repository includes preprocessing, prototype extraction, GRPO training, progressive generation, recommendation backends, Vec2Text-style inversion, and Replay-MLE source re-identification.</p>
+          <p class="section-kicker">Motivation</p>
+          <h2>Semantic privacy is a relational problem.</h2>
         </div>
-        <div class="resource-actions">
-          <a href="https://github.com/Shengxiang-Lin/PGPO" target="_blank" rel="noopener">Explore the code <span>↗</span></a>
-          <a href="https://github.com/Shengxiang-Lin/PGPO/tree/main/evaluate" target="_blank" rel="noopener">Read the evaluation guide <span>↗</span></a>
-        </div>
+        <p>Changing individual words is not enough. Useful recommendation signals live in the geometry between items; privacy protection must shift exposed content without dismantling that geometry.</p>
+      </div>
+
+      <figure class="paper-figure figure-framed">
+        <img src="assets/motivation.webp" alt="Comparison of original text, conventional word-level perturbation, and PGPO relational-fidelity obfuscation" width="1780" height="720" loading="lazy">
+        <figcaption><strong>Relational fidelity.</strong> PGPO obfuscates sensitive textual semantics while preserving the relative item relationships required by downstream recommenders.</figcaption>
+      </figure>
+
+      <div class="thesis-grid" aria-label="Problem formulation">
+        <article>
+          <span class="index">01</span>
+          <h3>Shift individual semantics</h3>
+          <p>Move each protected representation away from its original textual source to make reconstruction difficult.</p>
+        </article>
+        <article>
+          <span class="index">02</span>
+          <h3>Preserve local structure</h3>
+          <p>Maintain neighborhood ordering and relative relations so the recommender retains useful semantic evidence.</p>
+        </article>
+        <article>
+          <span class="index">03</span>
+          <h3>Optimize both together</h3>
+          <p>Balance privacy and utility explicitly rather than treating perturbation as an isolated preprocessing trick.</p>
+        </article>
       </div>
     </section>
 
-    <section class="section" id="citation">
-      <div class="shell narrow">
-        <div class="citation-heading">
-          <div>
-            <div class="eyebrow">Citation</div>
-            <h2>BibTeX</h2>
-          </div>
-          <button class="copy-button" type="button" data-copy="bibtex" aria-label="Copy BibTeX citation">
-            <span class="copy-icon" aria-hidden="true">⧉</span>
-            <span class="copy-label">Copy</span>
-          </button>
+    <section class="section section-tint" id="method">
+      <div class="section-heading">
+        <p class="section-kicker">Method</p>
+        <h2>Prototype-guided progressive obfuscation.</h2>
+        <p>PGPO first concentrates learning on structurally influential prototype words, then propagates the learned anchors through a static vocabulary-level semantic graph.</p>
+      </div>
+
+      <figure class="paper-figure framework-figure">
+        <img src="assets/framework.webp" alt="Overview of the PGPO framework, including graph construction, prototype exploration, and progressive expansion" width="2400" height="1100" loading="lazy">
+        <figcaption><strong>PGPO framework.</strong> Prototype-aware graph construction, GRPO-based anchor exploration, and progressive topology-preserving expansion.</figcaption>
+      </figure>
+
+      <div class="method-steps">
+        <article>
+          <div class="step-label">Stage 1</div>
+          <h3>Construct a semantic graph</h3>
+          <p>Build a static vocabulary graph and select high-influence prototype words that capture its structural backbone.</p>
+        </article>
+        <article>
+          <div class="step-label">Stage 2</div>
+          <h3>Learn prototype anchors</h3>
+          <p>Apply Group Relative Policy Optimization to explore privacy-preserving variants for the selected prototypes.</p>
+        </article>
+        <article>
+          <div class="step-label">Stage 3</div>
+          <h3>Expand progressively</h3>
+          <p>Generate variants for non-prototype words while conditioning on finalized neighbors and inherited topology.</p>
+        </article>
+      </div>
+
+      <div class="objective-block">
+        <div>
+          <p class="section-kicker">Optimization objective</p>
+          <h3>Three complementary rewards</h3>
         </div>
-        <p class="citation-note">Preliminary citation. The official BibTeX will be updated when the paper is released on arXiv and in the proceedings.</p>
-        <pre id="bibtex"><code>@inproceedings{lin2026pgpo,
-  title     = {PGPO: Prototype-Guided Progressive Obfuscation for
-               Privacy-Preserving LLM-Enhanced Recommendation},
-  author    = {Lin, Shengxiang and Su, Jiajie and Zhou, Pengyang and
-               Chen, Xiang and Zheng, Xiaolin and Tian, Feng and Chen, Chaochao},
+        <dl>
+          <div>
+            <dt>Individual dissimilarity</dt>
+            <dd>Encourages semantic separation between each original word and its protected variant.</dd>
+          </div>
+          <div>
+            <dt>Structural consistency</dt>
+            <dd>Preserves the relational topology between neighboring words after obfuscation.</dd>
+          </div>
+          <div>
+            <dt>Semantic constraint</dt>
+            <dd>Controls the shift so variants remain useful and optimization stays stable.</dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+
+    <section class="section" id="results">
+      <div class="section-heading split-heading">
+        <div>
+          <p class="section-kicker">Results</p>
+          <h2>Strong privacy, near-upper-bound utility.</h2>
+        </div>
+        <p>Across MovieLens-1M and Amazon-Book, PGPO substantially suppresses inversion while preserving recommendation performance close to using the original item descriptions.</p>
+      </div>
+
+      <div class="result-highlights">
+        <div><strong>51.8%</strong><span>lower exact-match inversion<br>on MovieLens-1M</span></div>
+        <div><strong>68.2%</strong><span>lower exact-match inversion<br>on Amazon-Book</span></div>
+        <div><strong>≈ upper bound</strong><span>recommendation utility<br>across model families</span></div>
+      </div>
+
+      <div class="table-block">
+        <div class="table-intro">
+          <h3>Recommendation performance</h3>
+          <p>Representative metrics from classical, multimodal, and LLM-based recommenders. “Description” is the unprotected upper bound.</p>
+        </div>
+        <div class="table-scroll" role="region" aria-label="Recommendation results" tabindex="0">
+          <table>
+            <thead>
+              <tr>
+                <th>Dataset</th>
+                <th>Input</th>
+                <th>SASRec<br><small>HR@10</small></th>
+                <th>LightGCN<br><small>HR@10</small></th>
+                <th>FREEDOM<br><small>HR@10</small></th>
+                <th>LightGT<br><small>HR@10</small></th>
+                <th>TALLRec<br><small>AUC</small></th>
+                <th>LLaRA<br><small>HR@1</small></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th rowspan="2">MovieLens-1M</th>
+                <td>Description</td><td>.1129</td><td>.0850</td><td>.0840</td><td>.0847</td><td>.6990</td><td>.2454</td>
+              </tr>
+              <tr class="accent-row">
+                <td>PGPO</td><td>.1133</td><td>.0848</td><td>.0842</td><td>.0839</td><td>.6978</td><td>.2451</td>
+              </tr>
+              <tr>
+                <th rowspan="2">Amazon-Book</th>
+                <td>Description</td><td>.1843</td><td>.0926</td><td>.0762</td><td>.0929</td><td>.7983</td><td>.5348</td>
+              </tr>
+              <tr class="accent-row">
+                <td>PGPO</td><td>.1846</td><td>.0920</td><td>.0753</td><td>.0930</td><td>.7979</td><td>.5257</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="embedding-grid">
+        <figure class="paper-figure">
+          <img src="assets/tsne-movielens.webp" alt="t-SNE visualization of original and obfuscated embeddings on MovieLens-1M" width="1200" height="860" loading="lazy">
+          <figcaption><strong>MovieLens-1M.</strong> PGPO changes exposed semantics while retaining a recognizable relational organization.</figcaption>
+        </figure>
+        <figure class="paper-figure">
+          <img src="assets/tsne-amazon.webp" alt="t-SNE visualization of original and obfuscated embeddings on Amazon-Book" width="1200" height="860" loading="lazy">
+          <figcaption><strong>Amazon-Book.</strong> The protected space preserves useful global structure across a denser vocabulary.</figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <section class="section section-dark" id="citation">
+      <div class="citation-grid">
+        <div>
+          <p class="section-kicker">Citation</p>
+          <h2>Cite PGPO</h2>
+          <p>The arXiv record is coming soon. We will update this entry when the official identifier is available.</p>
+          <a class="text-link" href="https://github.com/Shengxiang-Lin/PGPO">View source code on GitHub <span aria-hidden="true">↗</span></a>
+        </div>
+        <div class="bibtex-wrap">
+          <button class="copy-button" type="button" data-copy-target="bibtex">Copy BibTeX</button>
+          <pre id="bibtex"><code>@inproceedings{lin2026pgpo,
+  title     = {PGPO: Prototype-Guided Progressive Obfuscation for Privacy-Preserving LLM-Enhanced Recommendation},
+  author    = {Lin, Shengxiang and Su, Jiajie and Zhou, Pengyang and Chen, Xiang and Zheng, Xiaolin and Tian, Feng and Chen, Chaochao},
   booktitle = {Proceedings of EMNLP},
   year      = {2026}
 }</code></pre>
+        </div>
       </div>
-    </section>
 
-    <section class="section section-footer-info">
-      <div class="shell footer-info-grid">
-        <div>
-          <h2>Acknowledgments</h2>
-          <p>This work was supported by the National Natural Science Foundation of China (Nos. 72192823, 62177038, and 62522217).</p>
-        </div>
-        <div>
-          <h2>Contact</h2>
-          <p>Questions and collaborations are welcome.</p>
-          <a href="mailto:reallinshengxiang@gmail.com">reallinshengxiang@gmail.com</a>
-        </div>
+      <div class="acknowledgments">
+        <h3>Acknowledgments</h3>
+        <p>This work was supported by the National Natural Science Foundation of China (Nos. 72192823, 62177038, and 62522217).</p>
       </div>
     </section>
   </main>
 
-  <footer class="footer">
-    <div class="shell footer-row">
-      <div><strong>PGPO</strong> · Privacy-Preserving LLM-Enhanced Recommendation</div>
-      <div>© 2026 PGPO Project · <a href="https://github.com/Shengxiang-Lin/PGPO" target="_blank" rel="noopener">MIT License</a></div>
-    </div>
+  <footer>
+    <p>PGPO · EMNLP 2026</p>
+    <p>Correspondence: <a href="mailto:xlzheng@zju.edu.cn">xlzheng@zju.edu.cn</a> · <a href="mailto:fengtian@mail.xjtu.edu.cn">fengtian@mail.xjtu.edu.cn</a></p>
   </footer>
 
-  <button class="back-to-top" type="button" aria-label="Back to top">↑</button>
-
   <script>
-    const copyButton = document.querySelector('[data-copy="bibtex"]');
-    copyButton.addEventListener('click', async () => {
-      const text = document.getElementById('bibtex').innerText;
+    const copyButton = document.querySelector('[data-copy-target]');
+    copyButton?.addEventListener('click', async () => {
+      const text = document.getElementById(copyButton.dataset.copyTarget)?.innerText || '';
       try {
         await navigator.clipboard.writeText(text);
-        copyButton.classList.add('copied');
-        copyButton.querySelector('.copy-label').textContent = 'Copied';
-        setTimeout(() => {
-          copyButton.classList.remove('copied');
-          copyButton.querySelector('.copy-label').textContent = 'Copy';
-        }, 1800);
+        const original = copyButton.textContent;
+        copyButton.textContent = 'Copied';
+        setTimeout(() => { copyButton.textContent = original; }, 1600);
       } catch (_) {
-        window.getSelection().selectAllChildren(document.getElementById('bibtex'));
+        copyButton.textContent = 'Select & copy';
       }
     });
-
-    const backToTop = document.querySelector('.back-to-top');
-    window.addEventListener('scroll', () => {
-      backToTop.classList.toggle('visible', window.scrollY > 700);
-    }, { passive: true });
-    backToTop.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
   </script>
 </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,1179 +1,666 @@
 :root {
-  --navy-950: #06101d;
-  --navy-900: #091727;
-  --navy-800: #10253a;
-  --ink: #162133;
-  --muted: #5d6a7d;
-  --line: #dbe3ec;
+  --ink: #15213a;
+  --muted: #5f6980;
+  --line: #dbe0ea;
   --paper: #ffffff;
-  --tint: #f4f8fb;
-  --blue: #4f83b6;
-  --blue-deep: #2f6596;
-  --blue-soft: #8bb2d5;
-  --coral: #df765f;
-  --gold: #dca846;
-  --green: #72a795;
-  --shadow-sm: 0 8px 30px rgba(15, 34, 54, .08);
-  --shadow-lg: 0 24px 70px rgba(9, 23, 39, .13);
-  --radius: 20px;
-  --shell: 1180px;
+  --wash: #f5f7fb;
+  --blue: #2f61d5;
+  --blue-dark: #204cb5;
+  --navy: #111b31;
+  --max: 1180px;
+  --serif: "Source Serif 4", Georgia, serif;
+  --sans: "DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --mono: "DM Mono", ui-monospace, SFMono-Regular, Consolas, monospace;
 }
 
-* {
-  box-sizing: border-box;
-}
-
-html {
-  scroll-behavior: smooth;
-  scroll-padding-top: 80px;
-}
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
 
 body {
   margin: 0;
   color: var(--ink);
   background: var(--paper);
-  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-size: 16px;
-  line-height: 1.7;
+  font-family: var(--sans);
+  font-size: 17px;
+  line-height: 1.65;
   -webkit-font-smoothing: antialiased;
 }
 
-a {
-  color: inherit;
-}
-
-img {
-  display: block;
-  max-width: 100%;
-}
-
-button,
-a {
-  -webkit-tap-highlight-color: transparent;
-}
-
-:focus-visible {
-  outline: 3px solid #8dc8ff;
-  outline-offset: 4px;
-}
+a { color: inherit; }
+img { display: block; max-width: 100%; }
 
 .skip-link {
   position: fixed;
   z-index: 100;
-  top: 12px;
-  left: 12px;
-  padding: 10px 14px;
-  border-radius: 8px;
-  color: var(--navy-950);
-  background: #fff;
-  transform: translateY(-160%);
-  transition: transform .2s ease;
+  top: 10px;
+  left: 10px;
+  padding: 8px 12px;
+  color: #fff;
+  background: var(--navy);
+  transform: translateY(-150%);
 }
 
-.skip-link:focus {
-  transform: none;
-}
-
-.shell {
-  width: min(calc(100% - 48px), var(--shell));
-  margin-inline: auto;
-}
-
-.narrow {
-  max-width: 920px;
-}
+.skip-link:focus { transform: translateY(0); }
 
 .hero {
   position: relative;
-  min-height: 94vh;
+  min-height: 820px;
   overflow: hidden;
-  color: #fff;
+  border-bottom: 1px solid var(--line);
   background:
-    radial-gradient(circle at 15% 15%, rgba(79, 131, 182, .24), transparent 32%),
-    radial-gradient(circle at 86% 78%, rgba(223, 118, 95, .14), transparent 30%),
-    linear-gradient(137deg, var(--navy-950) 5%, var(--navy-900) 52%, #0c2034 100%);
+    radial-gradient(circle at 12% 22%, rgba(90, 127, 222, .13), transparent 26%),
+    radial-gradient(circle at 88% 76%, rgba(137, 113, 210, .10), transparent 27%),
+    linear-gradient(180deg, #fafbfe 0%, #f3f6fb 100%);
 }
 
 .hero::after {
   content: "";
   position: absolute;
-  inset: auto 0 0;
-  height: 150px;
-  background: linear-gradient(to bottom, transparent, rgba(6, 16, 29, .72));
+  inset: 0;
   pointer-events: none;
-}
-
-.hero-grid {
-  position: absolute;
-  inset: 0;
-  opacity: .18;
+  opacity: .36;
   background-image:
-    linear-gradient(rgba(255, 255, 255, .07) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, .07) 1px, transparent 1px);
-  background-size: 54px 54px;
-  mask-image: linear-gradient(to bottom, black, transparent 86%);
+    linear-gradient(rgba(41, 76, 139, .065) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(41, 76, 139, .065) 1px, transparent 1px);
+  background-size: 64px 64px;
+  mask-image: linear-gradient(to bottom, transparent 0%, #000 42%, transparent 96%);
 }
 
-.hero-network {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  opacity: .26;
-  filter: drop-shadow(0 0 10px rgba(139, 178, 213, .2));
-}
-
-.network-lines {
-  fill: none;
-  stroke: #8bb2d5;
-  stroke-width: 2;
-  stroke-dasharray: 7 10;
-}
-
-.network-nodes {
-  fill: #d8eaf9;
-  stroke: #4f83b6;
-  stroke-width: 4;
-}
-
-.network-nodes circle:nth-child(3n) {
-  fill: #df765f;
-  stroke: #df765f;
-}
-
-.network-nodes circle:nth-child(4n) {
-  fill: #dca846;
-  stroke: #dca846;
-}
-
-.nav {
+.paper-nav {
   position: relative;
-  z-index: 5;
+  z-index: 2;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  min-height: 86px;
-  border-bottom: 1px solid rgba(255, 255, 255, .12);
+  justify-content: flex-end;
+  gap: 34px;
+  width: min(calc(100% - 48px), var(--max));
+  margin: 0 auto;
+  padding: 28px 0;
+  border-bottom: 1px solid rgba(89, 102, 128, .19);
 }
 
-.brand {
-  display: inline-flex;
-  gap: 11px;
-  align-items: center;
-  color: #fff;
-  font-size: 1rem;
-  font-weight: 750;
+.paper-nav a {
+  color: #4c5870;
+  font-size: 14px;
+  font-weight: 600;
   text-decoration: none;
-  letter-spacing: .08em;
 }
 
-.brand-mark {
-  display: grid;
-  width: 34px;
-  height: 34px;
-  place-items: center;
-  border: 1px solid rgba(255, 255, 255, .28);
-  border-radius: 10px;
-  color: #fff;
-  background: linear-gradient(135deg, rgba(139, 178, 213, .46), rgba(79, 131, 182, .2));
-  font-weight: 800;
-}
+.paper-nav a:hover { color: var(--blue); }
 
-.nav-links {
-  display: flex;
-  gap: 32px;
-}
-
-.nav-links a {
-  color: rgba(255, 255, 255, .72);
-  font-size: .86rem;
-  font-weight: 550;
-  text-decoration: none;
-  transition: color .2s ease;
-}
-
-.nav-links a:hover {
-  color: #fff;
-}
-
-.hero-content {
+.hero-inner {
   position: relative;
-  z-index: 3;
-  display: flex;
-  min-height: calc(94vh - 86px);
-  padding: 74px 0 118px;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
+  z-index: 1;
+  width: min(calc(100% - 48px), 1240px);
+  margin: 0 auto;
+  padding: 100px 0 114px;
   text-align: center;
 }
 
-.venue-pill {
-  display: inline-flex;
-  gap: 9px;
-  align-items: center;
-  padding: 7px 14px;
-  border: 1px solid rgba(139, 178, 213, .28);
-  border-radius: 999px;
-  color: #dbeafa;
-  background: rgba(79, 131, 182, .13);
-  font-size: .77rem;
-  font-weight: 650;
-  letter-spacing: .08em;
-  text-transform: uppercase;
-  backdrop-filter: blur(12px);
-}
-
-.venue-pill span {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: #86d0b6;
-  box-shadow: 0 0 0 5px rgba(134, 208, 182, .11);
-}
-
-.hero h1 {
-  max-width: 1120px;
-  margin: 27px auto 18px;
-  color: #f8fbff;
-  font-size: clamp(2.45rem, 5.3vw, 4.9rem);
-  font-weight: 780;
-  letter-spacing: -.052em;
-  line-height: 1.08;
-  text-wrap: balance;
-  text-shadow: 0 12px 42px rgba(0, 0, 0, .22);
-}
-
-.title-accent {
-  color: #8bb2d5;
-}
-
-.hero-kicker {
-  margin: 0 0 31px;
-  color: rgba(233, 242, 251, .76);
-  font-size: clamp(1rem, 1.8vw, 1.28rem);
-  letter-spacing: .02em;
-}
-
-.authors {
-  display: flex;
-  max-width: 1060px;
-  margin: 0 auto;
-  flex-wrap: wrap;
-  gap: 2px 18px;
-  justify-content: center;
-}
-
-.authors a {
-  position: relative;
-  color: #fff;
-  font-size: .99rem;
-  font-weight: 550;
-  text-decoration: none;
-}
-
-.authors a::after {
-  content: "";
-  position: absolute;
-  right: 0;
-  bottom: 2px;
-  left: 0;
-  height: 1px;
-  background: rgba(139, 178, 213, .75);
-  transform: scaleX(0);
-  transform-origin: right;
-  transition: transform .22s ease;
-}
-
-.authors a:hover::after {
-  transform: scaleX(1);
-  transform-origin: left;
-}
-
-sup {
-  position: relative;
-  top: -.15em;
-  font-size: .66em;
-}
-
-.affiliations {
-  display: flex;
-  margin: 12px auto 0;
-  flex-wrap: wrap;
-  gap: 6px 22px;
-  justify-content: center;
-  color: rgba(229, 239, 248, .68);
-  font-size: .87rem;
-}
-
-.corresponding {
-  color: rgba(229, 239, 248, .54);
-  font-style: italic;
-}
-
-.hero-actions {
-  display: flex;
-  margin-top: 35px;
-  flex-wrap: wrap;
-  gap: 11px;
-  justify-content: center;
-}
-
-.button {
-  display: inline-flex;
-  min-height: 47px;
-  padding: 0 18px;
-  border: 1px solid transparent;
-  border-radius: 999px;
-  align-items: center;
-  justify-content: center;
-  gap: 9px;
-  font-size: .87rem;
-  font-weight: 650;
-  text-decoration: none;
-  transition: transform .2s ease, background .2s ease, border-color .2s ease, box-shadow .2s ease;
-}
-
-.button:hover {
-  transform: translateY(-2px);
-}
-
-.button svg {
-  width: 18px;
-  height: 18px;
-  fill: currentColor;
-  stroke: currentColor;
-  stroke-width: 1.7;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.button-primary {
-  color: var(--navy-950);
-  background: #f7fbff;
-  box-shadow: 0 12px 32px rgba(0, 0, 0, .18);
-}
-
-.button-primary:hover {
-  background: #dcecff;
-}
-
-.button-light {
-  color: #edf6ff;
-  border-color: rgba(255, 255, 255, .22);
-  background: rgba(255, 255, 255, .07);
-  backdrop-filter: blur(10px);
-}
-
-.button-light:hover {
-  border-color: rgba(255, 255, 255, .4);
-  background: rgba(255, 255, 255, .12);
-}
-
-.button small {
-  color: rgba(255, 255, 255, .58);
-  font-size: .67rem;
+.venue,
+.section-kicker {
+  margin: 0 0 22px;
+  color: var(--blue);
+  font-family: var(--mono);
+  font-size: 12px;
   font-weight: 500;
-}
-
-.scroll-cue {
-  position: absolute;
-  z-index: 4;
-  bottom: 31px;
-  left: 50%;
-  display: grid;
-  width: 28px;
-  height: 45px;
-  border: 1px solid rgba(255, 255, 255, .25);
-  border-radius: 18px;
-  place-items: start center;
-  transform: translateX(-50%);
-}
-
-.scroll-cue span {
-  width: 3px;
-  height: 8px;
-  margin-top: 9px;
-  border-radius: 2px;
-  background: rgba(255, 255, 255, .72);
-  animation: scroll 1.8s ease-in-out infinite;
-}
-
-@keyframes scroll {
-  0%, 100% { transform: translateY(0); opacity: .3; }
-  50% { transform: translateY(15px); opacity: 1; }
-}
-
-.section {
-  padding: 105px 0;
-}
-
-.section-intro {
-  padding-top: 120px;
-}
-
-.section-tint {
-  border-top: 1px solid #e8eef4;
-  border-bottom: 1px solid #e8eef4;
-  background: var(--tint);
-}
-
-.eyebrow {
-  margin-bottom: 13px;
-  color: var(--blue-deep);
-  font-size: .75rem;
-  font-weight: 750;
-  letter-spacing: .16em;
-  text-transform: uppercase;
-}
-
-h2 {
-  margin: 0;
-  color: var(--ink);
-  font-size: clamp(2rem, 4vw, 3.25rem);
-  font-weight: 740;
-  letter-spacing: -.04em;
-  line-height: 1.15;
-  text-wrap: balance;
-}
-
-.lead {
-  margin: 29px 0 0;
-  color: #455469;
-  font-size: clamp(1.08rem, 2vw, 1.3rem);
-  line-height: 1.82;
-}
-
-.definition-card {
-  display: grid;
-  margin-top: 42px;
-  padding: 27px 31px;
-  border: 1px solid #d8e4ee;
-  border-radius: var(--radius);
-  grid-template-columns: auto 1fr;
-  gap: 23px;
-  align-items: center;
-  background: linear-gradient(135deg, #f7fbff, #eef5fa);
-  box-shadow: var(--shadow-sm);
-}
-
-.definition-icon {
-  display: grid;
-  width: 66px;
-  height: 66px;
-  border-radius: 18px;
-  place-items: center;
-  color: #fff;
-  background: linear-gradient(135deg, var(--blue), var(--blue-deep));
-}
-
-.definition-icon svg {
-  width: 42px;
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 3;
-  stroke-linecap: round;
-}
-
-.definition-card span {
-  color: var(--blue-deep);
-  font-size: .78rem;
-  font-weight: 750;
   letter-spacing: .12em;
   text-transform: uppercase;
 }
 
-.definition-card p {
-  margin: 4px 0 0;
-  color: #42536a;
-  font-size: 1.06rem;
-}
-
-.split {
-  display: grid;
-  grid-template-columns: minmax(0, .82fr) minmax(500px, 1.18fr);
-  gap: 60px;
+.venue {
+  display: inline-flex;
+  gap: 10px;
   align-items: center;
+  padding: 7px 13px;
+  border: 1px solid #cdd8ef;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, .65);
 }
 
-.split-copy h2 {
-  margin-bottom: 25px;
+h1 {
+  max-width: 1160px;
+  margin: 0 auto 42px;
+  color: #17213a;
+  font-family: var(--serif);
+  font-size: clamp(3rem, 5vw, 5.05rem);
+  font-weight: 500;
+  letter-spacing: -.045em;
+  line-height: .98;
+  text-wrap: balance;
 }
 
-.split-copy p {
-  margin: 0 0 17px;
-  color: #526176;
+h1 span { color: var(--blue); }
+
+.authors {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 3px 10px;
+  max-width: 1040px;
+  margin: 0 auto;
+  color: #202b43;
+  font-family: var(--serif);
+  font-size: 20px;
+  line-height: 1.8;
 }
 
-.check-list {
-  display: grid;
-  margin: 28px 0 0;
-  padding: 0;
-  gap: 11px;
-  list-style: none;
+.authors span { white-space: nowrap; }
+
+.authors a {
+  text-decoration-color: rgba(47, 97, 213, .28);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
 }
 
-.check-list li {
+.authors a:hover { color: var(--blue); }
+
+sup {
   position: relative;
-  padding-left: 29px;
-  color: #32465d;
-  font-size: .93rem;
-  font-weight: 550;
-}
-
-.check-list li::before {
-  content: "";
-  position: absolute;
-  top: .54em;
-  left: 2px;
-  width: 10px;
-  height: 6px;
-  border-bottom: 2px solid var(--green);
-  border-left: 2px solid var(--green);
-  transform: rotate(-45deg);
-}
-
-.media-card {
-  margin: 0;
-  overflow: hidden;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: #fff;
-  box-shadow: var(--shadow-lg);
-}
-
-.media-card img {
-  width: 100%;
-  height: auto;
-}
-
-.media-card figcaption {
-  padding: 16px 20px 18px;
-  border-top: 1px solid #edf1f5;
-  color: #6a7686;
-  font-size: .78rem;
-  line-height: 1.5;
-}
-
-.motivation-card {
-  padding: 16px 16px 0;
-}
-
-.motivation-card img {
-  min-height: 245px;
-  object-fit: contain;
-}
-
-.motivation-card figcaption {
-  margin-inline: -16px;
-}
-
-.section-heading {
-  max-width: 810px;
-  margin-bottom: 52px;
-}
-
-.section-heading p {
-  margin: 21px 0 0;
-  color: var(--muted);
-  font-size: 1.05rem;
-}
-
-.steps {
-  display: grid;
-  margin-bottom: 45px;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 18px;
-}
-
-.step {
-  position: relative;
-  min-height: 245px;
-  padding: 30px;
-  overflow: hidden;
-  border: 1px solid #dce5ed;
-  border-radius: 18px;
-  background: #fff;
-  transition: transform .25s ease, box-shadow .25s ease;
-}
-
-.step:hover {
-  box-shadow: var(--shadow-sm);
-  transform: translateY(-4px);
-}
-
-.step::after {
-  content: "";
-  position: absolute;
-  right: -45px;
-  bottom: -45px;
-  width: 120px;
-  height: 120px;
-  border-radius: 50%;
-  background: rgba(79, 131, 182, .07);
-}
-
-.step-number {
-  display: inline-block;
-  color: var(--blue-deep);
-  font-size: .74rem;
-  font-weight: 800;
-  letter-spacing: .14em;
-}
-
-.step h3 {
-  margin: 40px 0 11px;
-  color: var(--ink);
-  font-size: 1.28rem;
-  line-height: 1.25;
-}
-
-.step p {
-  margin: 0;
-  color: #617083;
-  font-size: .91rem;
-  line-height: 1.65;
-}
-
-.framework {
-  padding: 17px 17px 0;
-  background: #f7fafc;
-}
-
-.framework img {
-  border-radius: 10px;
-}
-
-.framework figcaption {
-  margin-inline: -17px;
-}
-
-.section-dark {
-  position: relative;
-  overflow: hidden;
-  color: #fff;
-  background:
-    radial-gradient(circle at 92% 8%, rgba(79, 131, 182, .22), transparent 28%),
-    linear-gradient(135deg, #07121f, #10283d);
-}
-
-.section-dark::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  opacity: .15;
-  background-image: radial-gradient(circle, rgba(255, 255, 255, .55) 1px, transparent 1px);
-  background-size: 32px 32px;
-  mask-image: linear-gradient(90deg, transparent, black 48%, transparent);
-}
-
-.section-dark .shell {
-  position: relative;
-}
-
-.section-heading.light h2 {
-  color: #f6faff;
-}
-
-.section-heading.light .eyebrow {
-  color: #90bde4;
-}
-
-.reward-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 18px;
-}
-
-.reward-card {
-  min-height: 265px;
-  padding: 30px;
-  border: 1px solid rgba(255, 255, 255, .11);
-  border-radius: 18px;
-  background: rgba(255, 255, 255, .055);
-  backdrop-filter: blur(7px);
-}
-
-.reward-card > span {
-  display: inline-grid;
-  min-width: 54px;
-  height: 39px;
-  padding-inline: 10px;
-  border-radius: 10px;
-  place-items: center;
-  font-family: Georgia, serif;
-  font-size: 1rem;
-  font-style: italic;
-}
-
-.reward-card.coral > span { color: #ffb5a6; background: rgba(223, 118, 95, .14); }
-.reward-card.blue > span { color: #b9dcfa; background: rgba(79, 131, 182, .18); }
-.reward-card.gold > span { color: #f5d58c; background: rgba(220, 168, 70, .15); }
-
-.reward-card h3 {
-  margin: 34px 0 13px;
-  color: #fff;
-  font-size: 1.25rem;
-}
-
-.reward-card p {
-  margin: 0;
-  color: rgba(226, 238, 249, .68);
-  font-size: .92rem;
-}
-
-.section-results {
-  background: #fff;
-}
-
-.metric-grid {
-  display: grid;
-  margin-bottom: 55px;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 14px;
-}
-
-.metric-card {
-  min-height: 220px;
-  padding: 27px 24px;
-  border: 1px solid #dce5ed;
-  border-radius: 18px;
-  background: linear-gradient(180deg, #fff, #f9fbfd);
-}
-
-.metric-value {
-  color: var(--blue-deep);
-  font-size: clamp(2rem, 3.5vw, 3rem);
-  font-weight: 770;
-  letter-spacing: -.05em;
-  line-height: 1;
-}
-
-.metric-label {
-  margin-top: 14px;
-  color: var(--ink);
-  font-size: .76rem;
-  font-weight: 750;
-  letter-spacing: .08em;
-  text-transform: uppercase;
-}
-
-.metric-card p {
-  margin: 18px 0 0;
-  color: #6a7788;
-  font-size: .83rem;
-  line-height: 1.55;
-}
-
-.embedding-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 20px;
-}
-
-.embedding-grid .media-card {
-  padding: 13px 13px 0;
-  box-shadow: var(--shadow-sm);
-}
-
-.embedding-grid img {
-  aspect-ratio: 1.28 / 1;
-  border-radius: 10px;
-  object-fit: cover;
-}
-
-.embedding-grid figcaption {
-  margin-inline: -13px;
-  color: #3d4f63;
+  top: -.2em;
+  color: var(--blue-dark);
+  font-family: var(--sans);
+  font-size: .62em;
   font-weight: 600;
-  text-align: center;
 }
 
-.results-note {
-  max-width: 850px;
-  margin: 30px auto 0;
-  color: #617083;
-  font-size: .91rem;
-  text-align: center;
+.affiliations {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 5px 26px;
+  margin: 12px auto 34px;
+  color: var(--muted);
+  font-size: 14px;
 }
 
-.resource-shell {
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+}
+
+.button {
+  display: inline-flex;
+  min-height: 48px;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  padding: 10px 19px;
+  border: 1px solid #cbd3e1;
+  border-radius: 4px;
+  color: #28344c;
+  background: rgba(255, 255, 255, .78);
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: border-color .15s ease, transform .15s ease, background .15s ease;
+}
+
+.button:hover {
+  border-color: #9baac3;
+  background: #fff;
+  transform: translateY(-1px);
+}
+
+.button-primary {
+  min-width: 184px;
+  border-color: var(--blue);
+  color: #fff;
+  background: var(--blue);
+}
+
+.button-primary:hover {
+  border-color: var(--blue-dark);
+  color: #fff;
+  background: var(--blue-dark);
+}
+
+.button small {
+  padding-left: 9px;
+  border-left: 1px solid rgba(255, 255, 255, .32);
+  color: rgba(255, 255, 255, .76);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: .03em;
+}
+
+.section {
+  width: min(calc(100% - 48px), var(--max));
+  margin: 0 auto;
+  padding: 116px 0;
+}
+
+.section-narrow { max-width: 900px; }
+
+.section h2 {
+  margin: 0;
+  color: #17213a;
+  font-family: var(--serif);
+  font-size: clamp(2.35rem, 4vw, 4.1rem);
+  font-weight: 500;
+  letter-spacing: -.035em;
+  line-height: 1.08;
+  text-wrap: balance;
+}
+
+.abstract-text {
+  margin: 38px 0 0;
+  color: #354058;
+  font-family: var(--serif);
+  font-size: 21px;
+  line-height: 1.82;
+}
+
+.abstract-text em {
+  color: var(--blue-dark);
+  font-style: normal;
+  font-weight: 600;
+}
+
+.ruled { border-top: 1px solid var(--line); }
+.section-heading { max-width: 790px; margin-bottom: 54px; }
+
+.section-heading > p:last-child {
+  margin: 26px 0 0;
+  color: var(--muted);
+  font-size: 18px;
+  line-height: 1.75;
+}
+
+.split-heading {
   display: grid;
-  grid-template-columns: 1.35fr .65fr;
+  max-width: none;
+  grid-template-columns: 1.25fr .75fr;
   gap: 80px;
   align-items: end;
 }
 
-.resource-shell p {
-  max-width: 720px;
-  margin: 22px 0 0;
-  color: var(--muted);
-}
+.split-heading > p:last-child { margin: 0 0 5px; }
+.paper-figure { margin: 0; }
 
-.resource-actions {
-  display: grid;
-  gap: 12px;
-}
-
-.resource-actions a {
-  display: flex;
-  padding: 17px 19px;
-  border: 1px solid #d5e0e9;
-  border-radius: 13px;
-  align-items: center;
-  justify-content: space-between;
-  color: #284762;
+.paper-figure img {
+  width: 100%;
+  height: auto;
   background: #fff;
-  font-size: .88rem;
-  font-weight: 650;
-  text-decoration: none;
-  transition: border-color .2s ease, transform .2s ease, box-shadow .2s ease;
 }
 
-.resource-actions a:hover {
-  border-color: #9dbcd6;
-  box-shadow: var(--shadow-sm);
-  transform: translateX(3px);
+.paper-figure figcaption {
+  margin-top: 16px;
+  color: #737d91;
+  font-size: 13px;
+  line-height: 1.6;
 }
 
-.resource-actions span {
+.paper-figure figcaption strong { color: #344057; }
+
+.figure-framed {
+  padding: 26px 26px 18px;
+  border: 1px solid var(--line);
+  background: #fbfcfe;
+}
+
+.thesis-grid,
+.method-steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  margin-top: 70px;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.thesis-grid article,
+.method-steps article {
+  padding: 34px 32px 38px;
+  border-right: 1px solid var(--line);
+}
+
+.thesis-grid article:first-child,
+.method-steps article:first-child { padding-left: 0; }
+
+.thesis-grid article:last-child,
+.method-steps article:last-child {
+  padding-right: 0;
+  border-right: 0;
+}
+
+.index,
+.step-label {
   color: var(--blue);
-  font-size: 1.15rem;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: .08em;
+  text-transform: uppercase;
 }
 
-.citation-heading {
+.thesis-grid h3,
+.method-steps h3,
+.objective-block h3,
+.table-intro h3,
+.acknowledgments h3 {
+  margin: 12px 0 10px;
+  color: #1b263e;
+  font-family: var(--serif);
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.thesis-grid p,
+.method-steps p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+.section-tint {
+  position: relative;
+  width: 100%;
+  max-width: none;
+  padding-right: max(24px, calc((100% - var(--max)) / 2));
+  padding-left: max(24px, calc((100% - var(--max)) / 2));
+  background: var(--wash);
+}
+
+.framework-figure {
+  padding: 28px;
+  border: 1px solid #d7deeb;
+  background: #fff;
+}
+
+.method-steps { margin-top: 62px; }
+
+.objective-block {
+  display: grid;
+  grid-template-columns: .72fr 1.28fr;
+  gap: 80px;
+  margin-top: 90px;
+  padding: 52px;
+  color: #e9edfa;
+  background: var(--navy);
+}
+
+.objective-block h3 {
+  margin-top: 0;
+  color: #fff;
+  font-size: 34px;
+}
+
+.objective-block dl { margin: 0; }
+
+.objective-block dl > div {
+  display: grid;
+  grid-template-columns: .8fr 1.2fr;
+  gap: 22px;
+  padding: 20px 0;
+  border-top: 1px solid rgba(255, 255, 255, .15);
+}
+
+.objective-block dl > div:first-child { padding-top: 0; border-top: 0; }
+.objective-block dl > div:last-child { padding-bottom: 0; }
+.objective-block dt { color: #fff; font-weight: 600; }
+
+.objective-block dd {
+  margin: 0;
+  color: #aeb9d1;
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.result-highlights {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  margin: 10px 0 88px;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.result-highlights div {
+  padding: 34px 28px;
+  border-right: 1px solid var(--line);
+}
+
+.result-highlights div:first-child { padding-left: 0; }
+.result-highlights div:last-child { border-right: 0; }
+
+.result-highlights strong {
+  display: block;
+  margin-bottom: 10px;
+  color: var(--blue);
+  font-family: var(--serif);
+  font-size: 44px;
+  font-weight: 500;
+  letter-spacing: -.035em;
+  line-height: 1;
+}
+
+.result-highlights span {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.table-block { margin-bottom: 90px; }
+
+.table-intro {
   display: flex;
-  align-items: end;
   justify-content: space-between;
+  gap: 36px;
+  align-items: end;
+  margin-bottom: 24px;
+}
+
+.table-intro h3 { margin: 0; font-size: 30px; }
+
+.table-intro p {
+  max-width: 560px;
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.table-scroll {
+  overflow-x: auto;
+  border-top: 2px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+}
+
+table {
+  width: 100%;
+  min-width: 820px;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 13px;
+}
+
+th, td {
+  padding: 14px 13px;
+  border-bottom: 1px solid var(--line);
+  text-align: center;
+  white-space: nowrap;
+}
+
+thead th {
+  color: #344057;
+  background: #f8f9fc;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+thead small { color: #788399; font-size: 9px; letter-spacing: 0; }
+tbody th, tbody td:nth-child(2) { text-align: left; }
+tbody th { font-weight: 500; }
+.accent-row { color: var(--blue-dark); background: #f1f5ff; }
+.accent-row td:nth-child(1) { font-weight: 600; }
+tbody tr:last-child td { border-bottom: 0; }
+
+.embedding-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 28px;
+}
+
+.embedding-grid figure {
+  padding: 18px 18px 14px;
+  border: 1px solid var(--line);
+  background: #fbfcfe;
+}
+
+.section-dark {
+  width: 100%;
+  max-width: none;
+  padding-right: max(24px, calc((100% - var(--max)) / 2));
+  padding-left: max(24px, calc((100% - var(--max)) / 2));
+  color: #b6c0d5;
+  background: var(--navy);
+}
+
+.section-dark h2 { color: #fff; }
+.section-dark .section-kicker { color: #91adff; }
+
+.citation-grid {
+  display: grid;
+  grid-template-columns: .65fr 1.35fr;
+  gap: 80px;
+}
+
+.citation-grid > div:first-child > p:not(.section-kicker) {
+  max-width: 400px;
+  color: #aeb8cd;
+}
+
+.text-link {
+  display: inline-block;
+  margin-top: 18px;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  text-underline-offset: 5px;
+}
+
+.bibtex-wrap { position: relative; }
+
+pre {
+  min-height: 100%;
+  margin: 0;
+  overflow-x: auto;
+  padding: 34px;
+  border: 1px solid #34415d;
+  color: #dce4f7;
+  background: #0c1427;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.75;
 }
 
 .copy-button {
-  display: inline-flex;
-  min-width: 104px;
-  padding: 11px 15px;
-  border: 1px solid #ccd9e4;
-  border-radius: 10px;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  color: #2d4963;
-  background: #fff;
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  padding: 7px 10px;
+  border: 1px solid #47546d;
+  border-radius: 3px;
+  color: #c8d2e8;
+  background: #18233b;
+  font: 500 11px var(--sans);
   cursor: pointer;
-  font: inherit;
-  font-size: .84rem;
-  font-weight: 650;
-  transition: background .2s ease, color .2s ease, border-color .2s ease;
 }
 
-.copy-button:hover {
-  border-color: var(--blue-soft);
-  background: #f4f9fd;
+.copy-button:hover { color: #fff; border-color: #6b7892; }
+
+.acknowledgments {
+  display: grid;
+  grid-template-columns: .35fr 1.65fr;
+  gap: 40px;
+  margin-top: 80px;
+  padding-top: 36px;
+  border-top: 1px solid rgba(255, 255, 255, .15);
 }
 
-.copy-button.copied {
-  color: #fff;
-  border-color: #5f9b82;
-  background: #5f9b82;
-}
-
-.copy-icon {
-  font-size: 1.05rem;
-}
-
-.citation-note {
-  margin: 23px 0 14px;
-  color: #6c7889;
-  font-size: .85rem;
-}
-
-pre {
+.acknowledgments h3 {
   margin: 0;
-  padding: 27px 30px;
-  overflow-x: auto;
-  border: 1px solid #d8e2eb;
-  border-radius: 16px;
-  color: #dcecff;
-  background: #0b1a2a;
-  box-shadow: var(--shadow-sm);
-  font: .83rem/1.7 "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  white-space: pre;
-}
-
-.section-footer-info {
-  padding: 75px 0;
-  color: #d9e5f0;
-  background: #0c1c2c;
-}
-
-.footer-info-grid {
-  display: grid;
-  grid-template-columns: 1.4fr .6fr;
-  gap: 90px;
-}
-
-.footer-info-grid h2 {
   color: #fff;
-  font-size: 1.35rem;
-  letter-spacing: -.02em;
+  font-family: var(--sans);
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: .06em;
 }
 
-.footer-info-grid p {
-  margin: 13px 0 0;
-  color: rgba(218, 231, 242, .64);
-  font-size: .91rem;
-}
+.acknowledgments p { margin: 0; font-size: 14px; }
 
-.footer-info-grid a {
-  display: inline-block;
-  margin-top: 8px;
-  color: #a9cceb;
-  font-size: .9rem;
-  text-underline-offset: 3px;
-}
-
-.footer {
-  padding: 25px 0;
-  border-top: 1px solid rgba(255, 255, 255, .07);
-  color: rgba(217, 230, 241, .48);
-  background: #07131f;
-  font-size: .75rem;
-}
-
-.footer-row {
+footer {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  gap: 20px;
+  gap: 30px;
+  padding: 24px max(24px, calc((100% - var(--max)) / 2));
+  border-top: 1px solid #2d3850;
+  color: #8f9bb2;
+  background: #0c1427;
+  font-size: 12px;
 }
 
-.footer strong {
-  color: rgba(238, 246, 253, .82);
+footer p { margin: 0; }
+footer a { color: #c8d2e8; }
+
+@media (max-width: 900px) {
+  .hero { min-height: auto; }
+  .hero-inner { padding: 80px 0 92px; }
+  .paper-nav { justify-content: center; }
+  h1 { font-size: clamp(2.65rem, 8vw, 4.4rem); }
+  .split-heading,
+  .objective-block,
+  .citation-grid { grid-template-columns: 1fr; gap: 34px; }
+  .split-heading > p:last-child { margin: 0; }
+  .objective-block { padding: 38px; }
+  .table-intro { display: block; }
+  .table-intro p { margin-top: 10px; }
+  .result-highlights strong { font-size: 36px; }
 }
 
-.footer a {
-  color: rgba(211, 231, 249, .72);
-}
-
-.back-to-top {
-  position: fixed;
-  z-index: 20;
-  right: 24px;
-  bottom: 24px;
-  display: grid;
-  width: 46px;
-  height: 46px;
-  border: 1px solid rgba(255, 255, 255, .18);
-  border-radius: 50%;
-  place-items: center;
-  color: #fff;
-  background: rgba(9, 23, 39, .9);
-  box-shadow: 0 12px 34px rgba(0, 0, 0, .18);
-  opacity: 0;
-  cursor: pointer;
-  pointer-events: none;
-  transform: translateY(12px);
-  transition: opacity .2s ease, transform .2s ease;
-}
-
-.back-to-top.visible {
-  opacity: 1;
-  pointer-events: auto;
-  transform: none;
-}
-
-@media (max-width: 1020px) {
-  .split {
-    grid-template-columns: 1fr;
-    gap: 38px;
-  }
-
-  .motivation-card {
-    max-width: 820px;
-  }
-
-  .metric-grid {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .resource-shell {
-    grid-template-columns: 1fr;
-    gap: 38px;
-    align-items: start;
-  }
-
-  .resource-actions {
-    max-width: 520px;
-  }
-}
-
-@media (max-width: 780px) {
-  .shell {
-    width: min(calc(100% - 30px), var(--shell));
-  }
-
-  .nav {
-    min-height: 70px;
-  }
-
-  .nav-links {
-    display: none;
-  }
-
-  .hero-content {
-    min-height: calc(94vh - 70px);
-    padding: 58px 0 95px;
-  }
-
-  .hero h1 {
-    font-size: clamp(2.2rem, 10.5vw, 3.65rem);
-    line-height: 1.08;
-  }
-
-  .hero-kicker {
-    max-width: 470px;
-  }
-
-  .authors {
-    gap: 4px 13px;
-  }
-
-  .authors a {
-    font-size: .87rem;
-  }
-
-  .affiliations {
-    max-width: 520px;
-    font-size: .78rem;
-  }
-
-  .section {
-    padding: 77px 0;
-  }
-
-  .section-intro {
-    padding-top: 86px;
-  }
-
-  .definition-card {
-    padding: 24px;
-    grid-template-columns: 1fr;
-  }
-
-  .definition-icon {
-    width: 57px;
-    height: 57px;
-  }
-
-  .steps,
-  .reward-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .step,
-  .reward-card {
-    min-height: auto;
-  }
-
-  .step h3 {
-    margin-top: 24px;
-  }
-
-  .embedding-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .footer-info-grid {
-    grid-template-columns: 1fr;
-    gap: 42px;
-  }
-
-  .footer-row {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-@media (max-width: 520px) {
-  .hero {
-    min-height: 100svh;
-  }
-
-  .hero-content {
-    min-height: calc(100svh - 70px);
-  }
-
-  .venue-pill {
-    font-size: .65rem;
-  }
-
-  .hero-actions {
-    width: 100%;
-  }
-
-  .button {
-    width: 100%;
-  }
-
-  .corresponding {
-    flex-basis: 100%;
-  }
-
-  .metric-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .metric-card {
-    min-height: auto;
-  }
-
-  .citation-heading {
-    gap: 22px;
-    align-items: center;
-  }
-
-  .copy-button {
-    min-width: 88px;
-  }
-
-  pre {
-    padding: 20px;
-    font-size: .73rem;
-  }
+@media (max-width: 680px) {
+  body { font-size: 16px; }
+  .paper-nav { gap: 20px; padding: 20px 0; }
+  .paper-nav a { font-size: 12px; }
+  .hero-inner { width: min(calc(100% - 32px), 1240px); padding: 62px 0 72px; }
+  h1 { margin-bottom: 32px; font-size: clamp(2.35rem, 11vw, 3.5rem); line-height: 1.02; }
+  .authors { gap: 1px 8px; font-size: 17px; line-height: 1.7; }
+  .affiliations { display: grid; gap: 3px; margin-bottom: 28px; }
+  .hero-actions { align-items: stretch; }
+  .button { flex: 1 1 140px; }
+  .button-primary { flex-basis: 100%; }
+  .section { width: min(calc(100% - 32px), var(--max)); padding: 76px 0; }
+  .section h2 { font-size: 2.45rem; }
+  .abstract-text { margin-top: 28px; font-size: 18px; line-height: 1.72; }
+  .section-tint,
+  .section-dark { width: 100%; padding-right: 16px; padding-left: 16px; }
+  .figure-framed,
+  .framework-figure { padding: 12px; }
+  .thesis-grid,
+  .method-steps,
+  .result-highlights,
+  .embedding-grid { grid-template-columns: 1fr; }
+  .thesis-grid article,
+  .method-steps article,
+  .result-highlights div { padding: 26px 0; border-right: 0; border-bottom: 1px solid var(--line); }
+  .thesis-grid article:last-child,
+  .method-steps article:last-child,
+  .result-highlights div:last-child { border-bottom: 0; }
+  .objective-block { margin-top: 64px; padding: 28px 22px; }
+  .objective-block dl > div { grid-template-columns: 1fr; gap: 6px; }
+  .result-highlights { margin-bottom: 64px; }
+  .embedding-grid { gap: 18px; }
+  .citation-grid { gap: 46px; }
+  pre { padding: 52px 20px 24px; font-size: 10px; }
+  .acknowledgments { grid-template-columns: 1fr; gap: 12px; margin-top: 60px; }
+  footer { display: block; text-align: center; }
+  footer p + p { margin-top: 6px; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  html {
-    scroll-behavior: auto;
-  }
-
-  *,
-  *::before,
-  *::after {
-    scroll-behavior: auto !important;
-    animation-duration: .01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: .01ms !important;
-  }
-}
-
-@media print {
-  .hero {
-    min-height: auto;
-  }
-
-  .nav-links,
-  .scroll-cue,
-  .back-to-top {
-    display: none;
-  }
-
-  .section {
-    padding: 40px 0;
-  }
-
-  .media-card,
-  .step,
-  .metric-card {
-    box-shadow: none;
-  }
+  html { scroll-behavior: auto; }
+  *, *::before, *::after { transition-duration: .01ms !important; }
 }


### PR DESCRIPTION
## Summary

Redesigns the PGPO GitHub Pages site as a paper-focused academic project page, taking visual cues from Aurora-LM and PosterCopilot.

### What changed

- removes the standalone PGPO brand header and product-style dark hero
- rebuilds the title, author, affiliation, and corresponding-author markup in stable HTML
- gives the paper title, authors, affiliations, Paper/Code/Evaluation links clear visual priority
- restructures the narrative as Abstract → Motivation → Method → Results → Citation
- uses the paper's motivation/framework/t-SNE figures as the primary visual material
- adds representative recommendation results in an academic table
- keeps the paper link pointed to the repository and marks arXiv as coming soon
- preserves the funding acknowledgment and correspondence details
- adds responsive behavior for author wrapping, figures, tables, and mobile layouts

### Validation

- `git diff --check` passes
- all referenced local assets exist
- seven author entries and both corresponding-author markers are explicit HTML, not Markdown