### PR TITLE
Redesign PGPO project page with a modern research-site style

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,262 +3,536 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="theme-color" content="#f7f8fc">
-  <meta name="description" content="PGPO learns topology-aware obfuscation for privacy-preserving LLM-enhanced recommendation.">
-  <meta property="og:title" content="PGPO — Prototype-Guided Progressive Obfuscation">
-  <meta property="og:description" content="Preserving relational fidelity for private LLM-enhanced recommendation.">
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://shengxiang-lin.github.io/PGPO/">
+  <script>
+    (function () {
+      var saved = localStorage.getItem('pgpo-theme');
+      if (saved === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
+    })();
+  </script>
+
   <title>PGPO — Privacy-Preserving LLM-Enhanced Recommendation</title>
+  <meta name="description" content="PGPO is an EMNLP 2026 Main Conference work on topology-aware semantic obfuscation for privacy-preserving LLM-enhanced recommendation.">
+  <meta name="author" content="Shengxiang Lin, Jiajie Su, Pengyang Zhou, Xiang Chen, Xiaolin Zheng, Feng Tian, Chaochao Chen">
+  <meta name="robots" content="index,follow">
+  <link rel="canonical" href="https://shengxiang-lin.github.io/PGPO/">
+
+  <meta name="citation_title" content="PGPO: Prototype-Guided Progressive Obfuscation for Privacy-Preserving LLM-Enhanced Recommendation">
+  <meta name="citation_author" content="Lin, Shengxiang">
+  <meta name="citation_author" content="Su, Jiajie">
+  <meta name="citation_author" content="Zhou, Pengyang">
+  <meta name="citation_author" content="Chen, Xiang">
+  <meta name="citation_author" content="Zheng, Xiaolin">
+  <meta name="citation_author" content="Tian, Feng">
+  <meta name="citation_author" content="Chen, Chaochao">
+  <meta name="citation_publication_date" content="2026">
+  <meta name="citation_conference_title" content="Proceedings of the 2026 Conference on Empirical Methods in Natural Language Processing">
+
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="PGPO — Prototype-Guided Progressive Obfuscation">
+  <meta property="og:description" content="Protect textual privacy in LLM-enhanced recommendation while preserving relational fidelity. EMNLP 2026 Main Conference.">
+  <meta property="og:url" content="https://shengxiang-lin.github.io/PGPO/">
+  <meta property="og:image" content="https://raw.githubusercontent.com/Shengxiang-Lin/PGPO/main/docs/assets/framework.webp">
+  <meta property="og:site_name" content="PGPO">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="PGPO — Privacy-Preserving LLM-Enhanced Recommendation">
+  <meta name="twitter:description" content="Prototype-guided GRPO for topology-aware semantic obfuscation. EMNLP 2026 Main Conference.">
+  <meta name="twitter:image" content="https://raw.githubusercontent.com/Shengxiang-Lin/PGPO/main/docs/assets/framework.webp">
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=DM+Sans:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <a class="skip-link" href="#content">Skip to content</a>
 
-  <header class="hero" id="top">
-    <nav class="paper-nav" aria-label="Page sections">
-      <a href="#abstract">Abstract</a>
-      <a href="#method">Method</a>
-      <a href="#results">Results</a>
-      <a href="#citation">Citation</a>
+<body>
+  <div class="ambient ambient-one" aria-hidden="true"></div>
+  <div class="ambient ambient-two" aria-hidden="true"></div>
+
+  <div class="page-shell">
+    <nav class="topbar" aria-label="Primary navigation">
+      <a class="brand" href="#top" aria-label="PGPO home">
+        <span class="brand-mark">P</span>
+        <span>PGPO</span>
+      </a>
+
+      <div class="nav-links">
+        <a href="#overview">Overview</a>
+        <a href="#method">Method</a>
+        <a href="#results">Results</a>
+        <a href="#resources">Resources</a>
+      </div>
+
+      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle color theme"></button>
     </nav>
 
-    <div class="hero-inner">
-      <p class="venue">EMNLP 2026 <span aria-hidden="true">·</span> Main Conference</p>
-
-      <h1><span>PGPO:</span> Prototype-Guided Progressive Obfuscation for Privacy-Preserving LLM-Enhanced Recommendation</h1>
-
-      <div class="authors" aria-label="Authors">
-        <span><a href="https://Shengxiang-Lin.github.io/">Shengxiang Lin</a><sup>1</sup>,</span>
-        <span><a href="https://scholar.google.com/citations?hl=zh-CN&amp;user=tn09CCIAAAAJ&amp;view_op=list_works&amp;sortby=pubdate">Jiajie Su</a><sup>1</sup>,</span>
-        <span><a href="https://scholar.google.com/citations?hl=zh-CN&amp;user=3LnDqE4AAAAJ&amp;view_op=list_works&amp;sortby=pubdate">Pengyang Zhou</a><sup>1</sup>,</span>
-        <span><a href="https://scholar.google.com/citations?user=ZMdsjDUAAAAJ&amp;hl=zh-CN&amp;oi=sra">Xiang Chen</a><sup>1</sup>,</span>
-        <span><a href="https://person.zju.edu.cn/xlzheng#0">Xiaolin Zheng</a><sup>1,&#42;</sup>,</span>
-        <span><a href="https://www.xjtu.edu.cn/jsnr.jsp?wbtreeid=1632&amp;wbwbxjtuteacherid=1473">Feng Tian</a><sup>2,&#42;</sup>,</span>
-        <span><a href="https://person.zju.edu.cn/zjuccc">Chaochao Chen</a><sup>1</sup></span>
-      </div>
-
-      <div class="affiliations">
-        <span><sup>1</sup> Zhejiang University</span>
-        <span><sup>2</sup> Xi'an Jiaotong University</span>
-        <span><sup>&#42;</sup> Corresponding authors</span>
-      </div>
-
-      <div class="hero-actions" aria-label="Paper resources">
-        <a class="button button-primary" href="https://github.com/Shengxiang-Lin/PGPO">
-          <span>Paper</span><small>arXiv coming soon</small>
-        </a>
-        <a class="button" href="https://github.com/Shengxiang-Lin/PGPO">Code <span aria-hidden="true">↗</span></a>
-        <a class="button" href="https://github.com/Shengxiang-Lin/PGPO/tree/main/evaluate">Evaluation <span aria-hidden="true">↗</span></a>
-      </div>
-    </div>
-  </header>
-
-  <main id="content">
-    <section class="section section-narrow" id="abstract">
-      <p class="section-kicker">Abstract</p>
-      <h2>Protect what an embedding reveals.<br>Preserve what recommendation needs.</h2>
-      <p class="abstract-text">LLM-enhanced recommender systems encode item side information into semantic embeddings, but these embeddings may leak sensitive textual attributes through inversion attacks. Existing input-side defenses rely on trusted collection or local token perturbation, often disrupting the inter-item semantic topology needed for recommendation. To address it, we introduce <em>relational fidelity</em> as the key objective, requiring semantic shift for privacy while preserving relative item relations for utility. Based on this principle, we propose prototype-guided progressive obfuscation (PGPO), which learns topology-aware obfuscation anchors for high-influence prototype words and propagates them through a static semantic graph. PGPO is optimized with GRPO using individual dissimilarity, structural consistency, and semantic constraint rewards. Experiments on two benchmarks show strong inversion defense with near-upper-bound recommendation performance.</p>
-    </section>
-
-    <section class="section ruled" id="overview">
-      <div class="section-heading split-heading">
-        <div>
-          <p class="section-kicker">Motivation</p>
-          <h2>Semantic privacy is a relational problem.</h2>
+    <main id="top">
+      <header class="hero">
+        <div class="venue-row">
+          <span class="venue">EMNLP 2026 · Main Conference</span>
+          <span class="venue venue-soft">Open Source</span>
         </div>
-        <p>Changing individual words is not enough. Useful recommendation signals live in the geometry between items; privacy protection must shift exposed content without dismantling that geometry.</p>
-      </div>
 
-      <figure class="paper-figure figure-framed">
-        <img src="assets/motivation.webp" alt="Comparison of original text, conventional word-level perturbation, and PGPO relational-fidelity obfuscation" width="1780" height="720" loading="lazy">
-        <figcaption><strong>Relational fidelity.</strong> PGPO obfuscates sensitive textual semantics while preserving the relative item relationships required by downstream recommenders.</figcaption>
+        <h1>
+          <span class="title-accent">PGPO:</span>
+          Prototype-Guided Progressive Obfuscation for Privacy-Preserving LLM-Enhanced Recommendation
+        </h1>
+
+        <p class="subtitle">
+          Topology-aware semantic obfuscation that protects textual privacy while preserving the
+          relational structure recommendation systems actually need.
+        </p>
+
+        <div class="authors" aria-label="Authors">
+          <a href="https://Shengxiang-Lin.github.io/">Shengxiang Lin</a><sup>1</sup>,
+          <a href="https://scholar.google.com/citations?hl=zh-CN&amp;user=tn09CCIAAAAJ&amp;view_op=list_works&amp;sortby=pubdate">Jiajie Su</a><sup>1</sup>,
+          <a href="https://scholar.google.com/citations?hl=zh-CN&amp;user=3LnDqE4AAAAJ&amp;view_op=list_works&amp;sortby=pubdate">Pengyang Zhou</a><sup>1</sup>,
+          <a href="https://scholar.google.com/citations?user=ZMdsjDUAAAAJ&amp;hl=zh-CN&amp;oi=sra">Xiang Chen</a><sup>1</sup>,
+          <a href="https://person.zju.edu.cn/xlzheng#0">Xiaolin Zheng</a><sup>1,*</sup>,
+          <a href="https://www.xjtu.edu.cn/jsnr.jsp?wbtreeid=1632&amp;wbwbxjtuteacherid=1473">Feng Tian</a><sup>2,*</sup>,
+          <a href="https://person.zju.edu.cn/zjuccc">Chaochao Chen</a><sup>1</sup>
+        </div>
+
+        <div class="affiliations">
+          <span><sup>1</sup> Zhejiang University</span>
+          <span><sup>2</sup> Xi'an Jiaotong University</span>
+          <span><sup>*</sup> Corresponding authors</span>
+        </div>
+
+        <div class="hero-actions" aria-label="Project links">
+          <span class="btn btn-muted" aria-label="Paper coming soon">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6.5 2.8h8l3 3v15.4h-11zM14.5 2.8v4h4M9 11h6M9 14.5h6M9 18h4"/></svg>
+            Paper · arXiv soon
+          </span>
+
+          <a class="btn btn-primary" href="https://github.com/Shengxiang-Lin/PGPO">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" stroke="none" d="M12 .7A11.3 11.3 0 0 0 8.4 22.8c.6.1.8-.3.8-.6v-2.1c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.4-1.3-5.4-5.9 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.3 11.3 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.6 1.7.2 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.4 5.9.4.4.8 1.1.8 2.1v3.2c0 .3.2.7.8.6A11.3 11.3 0 0 0 12 .7z"/></svg>
+            Code
+          </a>
+
+          <a class="btn" href="https://huggingface.co/Shengxiang-Lin/PGPO">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.3 8.7c0-3 2-5.2 4.7-5.2s4.7 2.2 4.7 5.2v3.5c0 4-2 7-4.7 8.3-2.7-1.3-4.7-4.3-4.7-8.3zM9.7 9.2h.1M14.2 9.2h.1M9.7 13c1.5 1.2 3.1 1.2 4.6 0"/></svg>
+            Models
+          </a>
+
+          <a class="btn" href="https://github.com/Shengxiang-Lin/PGPO/tree/main/evaluate">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 19V9M10 19V5M16 19v-7M22 19V2"/></svg>
+            Evaluation
+          </a>
+        </div>
+      </header>
+
+      <figure class="hero-figure reveal">
+        <img src="assets/framework.webp" alt="PGPO framework: prototype-aware graph construction, GRPO-based anchor exploration, and progressive expansion">
+        <figcaption>
+          PGPO learns privacy-preserving obfuscation anchors for structurally influential prototype words,
+          then propagates them through a vocabulary-level semantic graph.
+        </figcaption>
       </figure>
 
-      <div class="thesis-grid" aria-label="Problem formulation">
-        <article>
-          <span class="index">01</span>
-          <h3>Shift individual semantics</h3>
-          <p>Move each protected representation away from its original textual source to make reconstruction difficult.</p>
-        </article>
-        <article>
-          <span class="index">02</span>
-          <h3>Preserve local structure</h3>
-          <p>Maintain neighborhood ordering and relative relations so the recommender retains useful semantic evidence.</p>
-        </article>
-        <article>
-          <span class="index">03</span>
-          <h3>Optimize both together</h3>
-          <p>Balance privacy and utility explicitly rather than treating perturbation as an isolated preprocessing trick.</p>
-        </article>
-      </div>
-    </section>
-
-    <section class="section section-tint" id="method">
-      <div class="section-heading">
-        <p class="section-kicker">Method</p>
-        <h2>Prototype-guided progressive obfuscation.</h2>
-        <p>PGPO first concentrates learning on structurally influential prototype words, then propagates the learned anchors through a static vocabulary-level semantic graph.</p>
-      </div>
-
-      <figure class="paper-figure framework-figure">
-        <img src="assets/framework.webp" alt="Overview of the PGPO framework, including graph construction, prototype exploration, and progressive expansion" width="2400" height="1100" loading="lazy">
-        <figcaption><strong>PGPO framework.</strong> Prototype-aware graph construction, GRPO-based anchor exploration, and progressive topology-preserving expansion.</figcaption>
-      </figure>
-
-      <div class="method-steps">
-        <article>
-          <div class="step-label">Stage 1</div>
-          <h3>Construct a semantic graph</h3>
-          <p>Build a static vocabulary graph and select high-influence prototype words that capture its structural backbone.</p>
-        </article>
-        <article>
-          <div class="step-label">Stage 2</div>
-          <h3>Learn prototype anchors</h3>
-          <p>Apply Group Relative Policy Optimization to explore privacy-preserving variants for the selected prototypes.</p>
-        </article>
-        <article>
-          <div class="step-label">Stage 3</div>
-          <h3>Expand progressively</h3>
-          <p>Generate variants for non-prototype words while conditioning on finalized neighbors and inherited topology.</p>
-        </article>
-      </div>
-
-      <div class="objective-block">
-        <div>
-          <p class="section-kicker">Optimization objective</p>
-          <h3>Three complementary rewards</h3>
+      <section id="overview" class="section reveal">
+        <div class="section-heading">
+          <span class="eyebrow">Overview · TL;DR</span>
+          <h2>Privacy protection should preserve relationships, not just words.</h2>
         </div>
-        <dl>
-          <div>
-            <dt>Individual dissimilarity</dt>
-            <dd>Encourages semantic separation between each original word and its protected variant.</dd>
-          </div>
-          <div>
-            <dt>Structural consistency</dt>
-            <dd>Preserves the relational topology between neighboring words after obfuscation.</dd>
-          </div>
-          <div>
-            <dt>Semantic constraint</dt>
-            <dd>Controls the shift so variants remain useful and optimization stays stable.</dd>
-          </div>
-        </dl>
-      </div>
-    </section>
 
-    <section class="section" id="results">
-      <div class="section-heading split-heading">
-        <div>
-          <p class="section-kicker">Results</p>
-          <h2>Strong privacy, near-upper-bound utility.</h2>
+        <div class="lead-block">
+          <p>
+            LLM-enhanced recommender systems encode item side information into semantic representations,
+            but those representations can expose sensitive textual attributes through inversion and
+            re-identification attacks. Conventional token-level perturbation can hide content while
+            simultaneously destroying the geometry that downstream recommendation relies on.
+          </p>
+          <p>
+            <strong>PGPO introduces relational fidelity as the central design principle:</strong>
+            move each protected representation away from its source while preserving relative semantic
+            structure across items.
+          </p>
         </div>
-        <p>Across MovieLens-1M and Amazon-Book, PGPO substantially suppresses inversion while preserving recommendation performance close to using the original item descriptions.</p>
-      </div>
 
-      <div class="result-highlights">
-        <div><strong>51.8%</strong><span>lower exact-match inversion<br>on MovieLens-1M</span></div>
-        <div><strong>68.2%</strong><span>lower exact-match inversion<br>on Amazon-Book</span></div>
-        <div><strong>≈ upper bound</strong><span>recommendation utility<br>across model families</span></div>
-      </div>
-
-      <div class="table-block">
-        <div class="table-intro">
-          <h3>Recommendation performance</h3>
-          <p>Representative metrics from classical, multimodal, and LLM-based recommenders. “Description” is the unprotected upper bound.</p>
-        </div>
-        <div class="table-scroll" role="region" aria-label="Recommendation results" tabindex="0">
-          <table>
-            <thead>
-              <tr>
-                <th>Dataset</th>
-                <th>Input</th>
-                <th>SASRec<br><small>HR@10</small></th>
-                <th>LightGCN<br><small>HR@10</small></th>
-                <th>FREEDOM<br><small>HR@10</small></th>
-                <th>LightGT<br><small>HR@10</small></th>
-                <th>TALLRec<br><small>AUC</small></th>
-                <th>LLaRA<br><small>HR@1</small></th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th rowspan="2">MovieLens-1M</th>
-                <td>Description</td><td>.1129</td><td>.0850</td><td>.0840</td><td>.0847</td><td>.6990</td><td>.2454</td>
-              </tr>
-              <tr class="accent-row">
-                <td>PGPO</td><td>.1133</td><td>.0848</td><td>.0842</td><td>.0839</td><td>.6978</td><td>.2451</td>
-              </tr>
-              <tr>
-                <th rowspan="2">Amazon-Book</th>
-                <td>Description</td><td>.1843</td><td>.0926</td><td>.0762</td><td>.0929</td><td>.7983</td><td>.5348</td>
-              </tr>
-              <tr class="accent-row">
-                <td>PGPO</td><td>.1846</td><td>.0920</td><td>.0753</td><td>.0930</td><td>.7979</td><td>.5257</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <div class="embedding-grid">
         <figure class="paper-figure">
-          <img src="assets/tsne-movielens.webp" alt="t-SNE visualization of original and obfuscated embeddings on MovieLens-1M" width="1200" height="860" loading="lazy">
-          <figcaption><strong>MovieLens-1M.</strong> PGPO changes exposed semantics while retaining a recognizable relational organization.</figcaption>
+          <img src="assets/motivation.webp" alt="Motivation for relational fidelity in privacy-preserving recommendation">
+          <figcaption>
+            Relational fidelity: shift exposed semantics for privacy while preserving neighborhood
+            relations for recommendation utility.
+          </figcaption>
         </figure>
-        <figure class="paper-figure">
-          <img src="assets/tsne-amazon.webp" alt="t-SNE visualization of original and obfuscated embeddings on Amazon-Book" width="1200" height="860" loading="lazy">
-          <figcaption><strong>Amazon-Book.</strong> The protected space preserves useful global structure across a denser vocabulary.</figcaption>
-        </figure>
-      </div>
-    </section>
 
-    <section class="section section-dark" id="citation">
-      <div class="citation-grid">
-        <div>
-          <p class="section-kicker">Citation</p>
+        <div class="card-grid three">
+          <article class="feature-card">
+            <span class="card-index">01</span>
+            <h3>Prototype-aware graph</h3>
+            <p>Find structurally influential vocabulary prototypes and precompute semantic neighborhoods.</p>
+          </article>
+
+          <article class="feature-card">
+            <span class="card-index">02</span>
+            <h3>GRPO exploration</h3>
+            <p>Learn obfuscation anchors that balance individual semantic shift and relational consistency.</p>
+          </article>
+
+          <article class="feature-card">
+            <span class="card-index">03</span>
+            <h3>Progressive expansion</h3>
+            <p>Propagate reliable prototype mappings to the rest of the vocabulary using finalized neighbors.</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="method" class="section reveal">
+        <div class="section-heading split">
+          <div>
+            <span class="eyebrow">Method</span>
+            <h2>Prototype-guided progressive obfuscation.</h2>
+          </div>
+          <p>
+            Instead of optimizing every word independently, PGPO first learns a compact set of trusted
+            obfuscation anchors and then expands from the semantic backbone outward.
+          </p>
+        </div>
+
+        <div class="method-flow">
+          <article>
+            <span class="flow-num">1</span>
+            <div>
+              <h3>Construct</h3>
+              <p>Build a static semantic graph and identify high-influence prototype words.</p>
+            </div>
+          </article>
+          <div class="flow-arrow" aria-hidden="true">→</div>
+          <article>
+            <span class="flow-num">2</span>
+            <div>
+              <h3>Explore</h3>
+              <p>Use GRPO to search for privacy-preserving variants for prototype anchors.</p>
+            </div>
+          </article>
+          <div class="flow-arrow" aria-hidden="true">→</div>
+          <article>
+            <span class="flow-num">3</span>
+            <div>
+              <h3>Expand</h3>
+              <p>Generate non-prototype variants conditioned on finalized neighboring mappings.</p>
+            </div>
+          </article>
+        </div>
+
+        <figure class="paper-figure wide">
+          <img src="assets/framework.webp" alt="Detailed PGPO framework">
+          <figcaption>
+            The full PGPO pipeline combines graph construction, prototype extraction, GRPO-based exploration,
+            cached neighborhood anchors, and progressive generation.
+          </figcaption>
+        </figure>
+
+        <div class="objective-panel">
+          <div>
+            <span class="eyebrow">Optimization</span>
+            <h3>Three signals, one privacy–utility objective.</h3>
+          </div>
+          <div class="reward-list">
+            <div>
+              <span>R₁</span>
+              <p><strong>Individual dissimilarity</strong><br>Push each variant away from its original semantic source.</p>
+            </div>
+            <div>
+              <span>R₂</span>
+              <p><strong>Structural consistency</strong><br>Preserve relative topology among neighboring vocabulary items.</p>
+            </div>
+            <div>
+              <span>R₃</span>
+              <p><strong>Semantic constraint</strong><br>Keep exploration valid and useful rather than arbitrarily destructive.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="results" class="section reveal">
+        <div class="section-heading">
+          <span class="eyebrow">Results</span>
+          <h2>Strong inversion resistance with near-upper-bound recommendation utility.</h2>
+        </div>
+
+        <div class="metric-grid">
+          <article class="metric-card">
+            <strong>51.8%</strong>
+            <span>lower exact-match inversion</span>
+            <small>MovieLens-1M</small>
+          </article>
+          <article class="metric-card">
+            <strong>68.2%</strong>
+            <span>lower exact-match inversion</span>
+            <small>Amazon-Book</small>
+          </article>
+          <article class="metric-card">
+            <strong>≈ upper bound</strong>
+            <span>recommendation utility</span>
+            <small>across multiple model families</small>
+          </article>
+        </div>
+
+        <div class="result-block">
+          <div class="result-copy">
+            <h3>Recommendation performance</h3>
+            <p>
+              PGPO stays close to the unprotected description upper bound across sequential, graph,
+              multimodal, and LLM-based recommenders.
+            </p>
+          </div>
+
+          <div class="table-wrap" role="region" aria-label="Recommendation results" tabindex="0">
+            <table>
+              <thead>
+                <tr>
+                  <th>Dataset</th>
+                  <th>Input</th>
+                  <th>SASRec<br><small>HR@10</small></th>
+                  <th>LightGCN<br><small>HR@10</small></th>
+                  <th>FREEDOM<br><small>HR@10</small></th>
+                  <th>LightGT<br><small>HR@10</small></th>
+                  <th>TALLRec<br><small>AUC</small></th>
+                  <th>LLaRA<br><small>HR@1</small></th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th rowspan="2">MovieLens-1M</th>
+                  <td>Description</td><td>.1129</td><td>.0850</td><td>.0840</td><td>.0847</td><td>.6990</td><td>.2454</td>
+                </tr>
+                <tr class="highlight-row">
+                  <td>PGPO</td><td>.1133</td><td>.0848</td><td>.0842</td><td>.0839</td><td>.6978</td><td>.2451</td>
+                </tr>
+                <tr>
+                  <th rowspan="2">Amazon-Book</th>
+                  <td>Description</td><td>.1843</td><td>.0926</td><td>.0762</td><td>.0929</td><td>.7983</td><td>.5348</td>
+                </tr>
+                <tr class="highlight-row">
+                  <td>PGPO</td><td>.1846</td><td>.0920</td><td>.0753</td><td>.0930</td><td>.7979</td><td>.5257</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="viz-grid">
+          <figure class="paper-figure compact">
+            <img src="assets/tsne-movielens.webp" alt="t-SNE visualization on MovieLens-1M">
+            <figcaption><strong>MovieLens-1M.</strong> Protected embeddings shift semantics while maintaining relational organization.</figcaption>
+          </figure>
+          <figure class="paper-figure compact">
+            <img src="assets/tsne-amazon.webp" alt="t-SNE visualization on Amazon-Book">
+            <figcaption><strong>Amazon-Book.</strong> PGPO preserves useful global structure under a denser vocabulary.</figcaption>
+          </figure>
+        </div>
+      </section>
+
+      <section id="resources" class="section reveal">
+        <div class="section-heading split">
+          <div>
+            <span class="eyebrow">Open source</span>
+            <h2>Reproduce, evaluate, extend.</h2>
+          </div>
+          <p>
+            The repository includes data preparation, semantic graph construction, prototype extraction,
+            GRPO training, generation, recommendation evaluation, and privacy-attack evaluation.
+          </p>
+        </div>
+
+        <div class="resource-grid">
+          <a class="resource-card" href="https://github.com/Shengxiang-Lin/PGPO">
+            <span class="resource-icon">⌘</span>
+            <div>
+              <h3>Code</h3>
+              <p>End-to-end training and evaluation pipeline.</p>
+            </div>
+            <span class="resource-arrow">↗</span>
+          </a>
+
+          <a class="resource-card" href="https://huggingface.co/Shengxiang-Lin/PGPO">
+            <span class="resource-icon">HF</span>
+            <div>
+              <h3>Model weights</h3>
+              <p>Released checkpoints for MovieLens-1M and Amazon-Book.</p>
+            </div>
+            <span class="resource-arrow">↗</span>
+          </a>
+
+          <a class="resource-card" href="https://github.com/Shengxiang-Lin/PGPO/tree/main/evaluate">
+            <span class="resource-icon">∑</span>
+            <div>
+              <h3>Evaluation</h3>
+              <p>Recommendation, inversion, and white-box re-identification.</p>
+            </div>
+            <span class="resource-arrow">↗</span>
+          </a>
+        </div>
+
+        <div class="quickstart">
+          <div class="quickstart-head">
+            <span>Quick start</span>
+            <button type="button" class="copy-btn" data-copy-target="quickstart-code">Copy</button>
+          </div>
+          <pre id="quickstart-code"><code>git clone https://github.com/Shengxiang-Lin/PGPO.git
+cd PGPO
+conda create -n pgpo python=3.10 -y
+conda activate pgpo
+pip install -r requirements.txt</code></pre>
+        </div>
+      </section>
+
+      <section id="faq" class="section reveal">
+        <div class="section-heading">
+          <span class="eyebrow">FAQ</span>
+          <h2>What PGPO is designed to solve.</h2>
+        </div>
+
+        <div class="faq-list">
+          <details>
+            <summary>Why not simply perturb item text or embeddings independently?</summary>
+            <div>
+              <p>
+                Independent perturbation can hide local semantics but may destroy the relative geometry among
+                items. PGPO explicitly optimizes relational fidelity so privacy protection preserves signals
+                needed by downstream recommendation.
+              </p>
+            </div>
+          </details>
+
+          <details>
+            <summary>Why use prototypes?</summary>
+            <div>
+              <p>
+                High-influence prototype words capture the semantic graph's structural backbone. Learning
+                reliable anchors there first makes subsequent expansion more stable and computationally focused.
+              </p>
+            </div>
+          </details>
+
+          <details>
+            <summary>What does the repository evaluate?</summary>
+            <div>
+              <p>
+                It includes recommendation backends, semantic and generation-quality analysis, embedding
+                inversion, and white-box source re-identification, enabling privacy and utility to be measured
+                together.
+              </p>
+            </div>
+          </details>
+
+          <details>
+            <summary>Which datasets are supported?</summary>
+            <div>
+              <p>MovieLens-1M and Amazon-Book are included in the released pipeline.</p>
+            </div>
+          </details>
+        </div>
+      </section>
+
+      <section id="citation" class="section reveal">
+        <div class="section-heading">
+          <span class="eyebrow">Citation</span>
           <h2>Cite PGPO</h2>
-          <p>The arXiv record is coming soon. We will update this entry when the official identifier is available.</p>
-          <a class="text-link" href="https://github.com/Shengxiang-Lin/PGPO">View source code on GitHub <span aria-hidden="true">↗</span></a>
+          <p class="section-note">The arXiv identifier will be added once the preprint is publicly available.</p>
         </div>
-        <div class="bibtex-wrap">
-          <button class="copy-button" type="button" data-copy-target="bibtex">Copy BibTeX</button>
-          <pre id="bibtex"><code>@inproceedings{lin2026pgpo,
+
+        <div class="bibtex-card">
+          <div class="bibtex-head">
+            <span>EMNLP 2026</span>
+            <button type="button" class="copy-btn" data-copy-target="bibtex-code">Copy BibTeX</button>
+          </div>
+          <pre id="bibtex-code"><code>@inproceedings{lin2026pgpo,
   title     = {PGPO: Prototype-Guided Progressive Obfuscation for Privacy-Preserving LLM-Enhanced Recommendation},
   author    = {Lin, Shengxiang and Su, Jiajie and Zhou, Pengyang and Chen, Xiang and Zheng, Xiaolin and Tian, Feng and Chen, Chaochao},
   booktitle = {Proceedings of EMNLP},
   year      = {2026}
 }</code></pre>
         </div>
-      </div>
 
-      <div class="acknowledgments">
-        <h3>Acknowledgments</h3>
-        <p>This work was supported by the National Natural Science Foundation of China (Nos. 72192823, 62177038, and 62522217).</p>
-      </div>
-    </section>
-  </main>
+        <div class="ack">
+          <strong>Acknowledgments</strong>
+          <p>This work was supported by the National Natural Science Foundation of China (Nos. 72192823, 62177038, and 62522217).</p>
+        </div>
+      </section>
+    </main>
 
-  <footer>
-    <p>PGPO · EMNLP 2026</p>
-    <p>Correspondence: <a href="mailto:xlzheng@zju.edu.cn">xlzheng@zju.edu.cn</a> · <a href="mailto:fengtian@mail.xjtu.edu.cn">fengtian@mail.xjtu.edu.cn</a></p>
-  </footer>
+    <footer>
+      <div>
+        <strong>PGPO</strong>
+        <span>EMNLP 2026 · Main Conference</span>
+      </div>
+      <p>
+        <a href="https://github.com/Shengxiang-Lin/PGPO">GitHub</a>
+        <span>·</span>
+        <a href="https://huggingface.co/Shengxiang-Lin/PGPO">Hugging Face</a>
+      </p>
+    </footer>
+  </div>
 
   <script>
-    const copyButton = document.querySelector('[data-copy-target]');
-    copyButton?.addEventListener('click', async () => {
-      const text = document.getElementById(copyButton.dataset.copyTarget)?.innerText || '';
-      try {
-        await navigator.clipboard.writeText(text);
-        const original = copyButton.textContent;
-        copyButton.textContent = 'Copied';
-        setTimeout(() => { copyButton.textContent = original; }, 1600);
-      } catch (_) {
-        copyButton.textContent = 'Select & copy';
+    (function () {
+      var root = document.documentElement;
+      var btn = document.getElementById('theme-toggle');
+
+      var sun = '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>';
+      var moon = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20.5 15.3A8.5 8.5 0 0 1 8.7 3.5a8.5 8.5 0 1 0 11.8 11.8z"/></svg>';
+
+      function dark() {
+        return root.getAttribute('data-theme') === 'dark';
       }
-    });
+
+      function paint() {
+        btn.innerHTML = dark() ? sun : moon;
+        btn.setAttribute('aria-label', dark() ? 'Switch to light theme' : 'Switch to dark theme');
+      }
+
+      btn.addEventListener('click', function () {
+        if (dark()) {
+          root.removeAttribute('data-theme');
+          localStorage.setItem('pgpo-theme', 'light');
+        } else {
+          root.setAttribute('data-theme', 'dark');
+          localStorage.setItem('pgpo-theme', 'dark');
+        }
+        paint();
+      });
+
+      paint();
+
+      var copyButtons = document.querySelectorAll('[data-copy-target]');
+      copyButtons.forEach(function (button) {
+        button.addEventListener('click', function () {
+          var target = document.getElementById(button.getAttribute('data-copy-target'));
+          if (!target) return;
+          var text = target.innerText;
+          var original = button.textContent;
+
+          function done() {
+            button.textContent = 'Copied';
+            setTimeout(function () { button.textContent = original; }, 1400);
+          }
+
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done);
+          }
+        });
+      });
+
+      var nodes = document.querySelectorAll('.reveal');
+      if ('IntersectionObserver' in window) {
+        var observer = new IntersectionObserver(function (entries) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting) {
+              entry.target.classList.add('visible');
+              observer.unobserve(entry.target);
+            }
+          });
+        }, { threshold: 0.08, rootMargin: '0px 0px -40px 0px' });
+
+        nodes.forEach(function (node) { observer.observe(node); });
+      } else {
+        nodes.forEach(function (node) { node.classList.add('visible'); });
+      }
+    })();
   </script>
 </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,666 +1,1165 @@
 :root {
-  --ink: #15213a;
-  --muted: #5f6980;
-  --line: #dbe0ea;
-  --paper: #ffffff;
-  --wash: #f5f7fb;
-  --blue: #2f61d5;
-  --blue-dark: #204cb5;
-  --navy: #111b31;
-  --max: 1180px;
-  --serif: "Source Serif 4", Georgia, serif;
-  --sans: "DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --mono: "DM Mono", ui-monospace, SFMono-Regular, Consolas, monospace;
+  --accent: #1768e5;
+  --accent-strong: #0b4dbc;
+  --accent-soft: #eaf2ff;
+  --accent-glow: rgba(23, 104, 229, .18);
+
+  --text: #252b35;
+  --text-strong: #121722;
+  --muted: #687383;
+  --bg: #ffffff;
+  --surface: rgba(255, 255, 255, .84);
+  --soft: #f6f8fb;
+  --soft-strong: #eef3f9;
+  --border: #dde3eb;
+  --border-strong: #cbd5e2;
+  --shadow: rgba(24, 50, 87, .10);
+
+  --max: 920px;
+  --radius: 14px;
+  --radius-lg: 20px;
+  --sans: "Manrope", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --mono: "DM Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 
-* { box-sizing: border-box; }
-html { scroll-behavior: smooth; }
+[data-theme="dark"] {
+  --accent: #69a7ff;
+  --accent-strong: #8bbaff;
+  --accent-soft: rgba(54, 126, 229, .14);
+  --accent-glow: rgba(63, 140, 255, .16);
+
+  --text: #cbd4df;
+  --text-strong: #f3f6fa;
+  --muted: #8e9aa9;
+  --bg: #0b1017;
+  --surface: rgba(18, 25, 35, .82);
+  --soft: #111924;
+  --soft-strong: #162130;
+  --border: #273445;
+  --border-strong: #34445a;
+  --shadow: rgba(0, 0, 0, .34);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 90px;
+}
 
 body {
   margin: 0;
-  color: var(--ink);
-  background: var(--paper);
+  color: var(--text);
+  background: var(--bg);
   font-family: var(--sans);
-  font-size: 17px;
-  line-height: 1.65;
+  font-size: 16px;
+  line-height: 1.72;
   -webkit-font-smoothing: antialiased;
+  transition: color .25s ease, background-color .25s ease;
 }
 
-a { color: inherit; }
-img { display: block; max-width: 100%; }
-
-.skip-link {
-  position: fixed;
-  z-index: 100;
-  top: 10px;
-  left: 10px;
-  padding: 8px 12px;
-  color: #fff;
-  background: var(--navy);
-  transform: translateY(-150%);
-}
-
-.skip-link:focus { transform: translateY(0); }
-
-.hero {
-  position: relative;
-  min-height: 820px;
-  overflow: hidden;
-  border-bottom: 1px solid var(--line);
-  background:
-    radial-gradient(circle at 12% 22%, rgba(90, 127, 222, .13), transparent 26%),
-    radial-gradient(circle at 88% 76%, rgba(137, 113, 210, .10), transparent 27%),
-    linear-gradient(180deg, #fafbfe 0%, #f3f6fb 100%);
-}
-
-.hero::after {
+body::before {
   content: "";
-  position: absolute;
+  position: fixed;
   inset: 0;
+  z-index: -3;
   pointer-events: none;
-  opacity: .36;
-  background-image:
-    linear-gradient(rgba(41, 76, 139, .065) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(41, 76, 139, .065) 1px, transparent 1px);
-  background-size: 64px 64px;
-  mask-image: linear-gradient(to bottom, transparent 0%, #000 42%, transparent 96%);
+  background:
+    radial-gradient(circle at 18% 8%, rgba(38, 119, 236, .08), transparent 28%),
+    radial-gradient(circle at 88% 30%, rgba(121, 93, 231, .06), transparent 26%),
+    linear-gradient(145deg, rgba(240, 247, 255, .45), rgba(255, 255, 255, 0) 48%);
 }
 
-.paper-nav {
-  position: relative;
-  z-index: 2;
-  display: flex;
-  justify-content: flex-end;
-  gap: 34px;
-  width: min(calc(100% - 48px), var(--max));
+[data-theme="dark"] body::before {
+  background:
+    radial-gradient(circle at 18% 8%, rgba(55, 131, 240, .12), transparent 28%),
+    radial-gradient(circle at 88% 30%, rgba(99, 78, 209, .08), transparent 26%);
+}
+
+.ambient {
+  position: fixed;
+  z-index: -2;
+  width: 420px;
+  height: 420px;
+  border-radius: 50%;
+  filter: blur(90px);
+  opacity: .16;
+  pointer-events: none;
+  animation: drift 18s ease-in-out infinite alternate;
+}
+
+.ambient-one {
+  top: -180px;
+  left: -150px;
+  background: #5aa2ff;
+}
+
+.ambient-two {
+  right: -180px;
+  top: 36%;
+  background: #8e7cf3;
+  animation-delay: -7s;
+}
+
+@keyframes drift {
+  from { transform: translate3d(0, 0, 0) scale(1); }
+  to { transform: translate3d(35px, 25px, 0) scale(1.08); }
+}
+
+a {
+  color: inherit;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.page-shell {
+  width: min(calc(100% - 36px), var(--max));
   margin: 0 auto;
-  padding: 28px 0;
-  border-bottom: 1px solid rgba(89, 102, 128, .19);
 }
 
-.paper-nav a {
-  color: #4c5870;
-  font-size: 14px;
-  font-weight: 600;
+.topbar {
+  position: sticky;
+  top: 14px;
+  z-index: 50;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 24px;
+  align-items: center;
+  margin-top: 14px;
+  padding: 10px 12px 10px 14px;
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  box-shadow: 0 10px 30px var(--shadow);
+  backdrop-filter: blur(16px);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--text-strong);
+  font-weight: 800;
   text-decoration: none;
 }
 
-.paper-nav a:hover { color: var(--blue); }
+.brand-mark {
+  display: grid;
+  width: 29px;
+  height: 29px;
+  place-items: center;
+  border-radius: 9px;
+  color: #fff;
+  background: linear-gradient(135deg, #0d4fb8, #267df5);
+  box-shadow: 0 5px 14px var(--accent-glow);
+  font-size: 13px;
+  font-weight: 800;
+}
 
-.hero-inner {
-  position: relative;
-  z-index: 1;
-  width: min(calc(100% - 48px), 1240px);
-  margin: 0 auto;
-  padding: 100px 0 114px;
+.nav-links {
+  display: flex;
+  justify-content: center;
+  gap: 22px;
+}
+
+.nav-links a {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: color .18s ease;
+}
+
+.nav-links a:hover {
+  color: var(--accent);
+}
+
+.theme-toggle {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  color: var(--muted);
+  background: var(--soft);
+  cursor: pointer;
+}
+
+.theme-toggle:hover {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.theme-toggle svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.hero {
+  padding: 108px 0 50px;
   text-align: center;
 }
 
-.venue,
-.section-kicker {
-  margin: 0 0 22px;
-  color: var(--blue);
-  font-family: var(--mono);
-  font-size: 12px;
-  font-weight: 500;
-  letter-spacing: .12em;
-  text-transform: uppercase;
+.venue-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 24px;
 }
 
 .venue {
   display: inline-flex;
-  gap: 10px;
   align-items: center;
-  padding: 7px 13px;
-  border: 1px solid #cdd8ef;
+  min-height: 30px;
+  padding: 5px 12px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, .65);
+  color: #fff;
+  background: linear-gradient(135deg, #0b4aa9, #1c74ef);
+  box-shadow: 0 7px 18px var(--accent-glow);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: .025em;
+}
+
+.venue-soft {
+  border: 1px solid var(--border-strong);
+  color: var(--accent-strong);
+  background: var(--surface);
+  box-shadow: none;
+}
+
+h1,
+h2,
+h3,
+p {
+  text-wrap: pretty;
 }
 
 h1 {
-  max-width: 1160px;
-  margin: 0 auto 42px;
-  color: #17213a;
-  font-family: var(--serif);
-  font-size: clamp(3rem, 5vw, 5.05rem);
-  font-weight: 500;
-  letter-spacing: -.045em;
-  line-height: .98;
-  text-wrap: balance;
+  max-width: 900px;
+  margin: 0 auto;
+  color: var(--text-strong);
+  font-size: clamp(2.55rem, 6.3vw, 4.55rem);
+  font-weight: 800;
+  letter-spacing: -.055em;
+  line-height: 1.03;
 }
 
-h1 span { color: var(--blue); }
+.title-accent {
+  color: var(--accent);
+}
+
+.subtitle {
+  max-width: 730px;
+  margin: 24px auto 0;
+  color: var(--muted);
+  font-size: clamp(1.02rem, 1.8vw, 1.18rem);
+  font-weight: 500;
+  line-height: 1.65;
+}
 
 .authors {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 3px 10px;
-  max-width: 1040px;
-  margin: 0 auto;
-  color: #202b43;
-  font-family: var(--serif);
-  font-size: 20px;
-  line-height: 1.8;
+  max-width: 840px;
+  margin: 28px auto 0;
+  color: var(--text);
+  font-size: 14px;
+  line-height: 2;
 }
-
-.authors span { white-space: nowrap; }
 
 .authors a {
-  text-decoration-color: rgba(47, 97, 213, .28);
-  text-decoration-thickness: 1px;
-  text-underline-offset: 4px;
+  color: var(--text-strong);
+  font-weight: 600;
+  text-decoration: none;
+  background-image: linear-gradient(90deg, var(--accent), var(--accent));
+  background-repeat: no-repeat;
+  background-position: left 100%;
+  background-size: 0 1px;
+  transition: color .18s ease, background-size .2s ease;
 }
 
-.authors a:hover { color: var(--blue); }
+.authors a:hover {
+  color: var(--accent);
+  background-size: 100% 1px;
+}
 
 sup {
-  position: relative;
-  top: -.2em;
-  color: var(--blue-dark);
-  font-family: var(--sans);
-  font-size: .62em;
-  font-weight: 600;
+  color: var(--accent);
+  font-size: .68em;
+  font-weight: 700;
 }
 
 .affiliations {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 5px 26px;
-  margin: 12px auto 34px;
+  gap: 5px 18px;
+  margin-top: 6px;
   color: var(--muted);
-  font-size: 14px;
+  font-size: 12px;
 }
 
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 10px;
+  gap: 9px;
+  margin-top: 27px;
 }
 
-.button {
+.btn {
   display: inline-flex;
-  min-height: 48px;
+  min-height: 43px;
   align-items: center;
   justify-content: center;
-  gap: 9px;
-  padding: 10px 19px;
-  border: 1px solid #cbd3e1;
-  border-radius: 4px;
-  color: #28344c;
-  background: rgba(255, 255, 255, .78);
-  font-size: 14px;
-  font-weight: 600;
+  gap: 8px;
+  padding: 9px 15px;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  color: var(--text-strong);
+  background: var(--surface);
+  box-shadow: 0 4px 14px rgba(24, 50, 87, .04);
+  font-size: 13px;
+  font-weight: 700;
   text-decoration: none;
-  transition: border-color .15s ease, transform .15s ease, background .15s ease;
+  transition: transform .16s ease, border-color .16s ease, color .16s ease, background .16s ease, box-shadow .16s ease;
 }
 
-.button:hover {
-  border-color: #9baac3;
-  background: #fff;
+.btn svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: 0 8px 20px var(--shadow);
   transform: translateY(-1px);
 }
 
-.button-primary {
-  min-width: 184px;
-  border-color: var(--blue);
+.btn-primary {
+  border-color: var(--accent);
   color: #fff;
-  background: var(--blue);
+  background: linear-gradient(135deg, #0c4ead, #1f76ed);
 }
 
-.button-primary:hover {
-  border-color: var(--blue-dark);
+.btn-primary:hover {
   color: #fff;
-  background: var(--blue-dark);
+  background: linear-gradient(135deg, #0b459a, #1769d5);
 }
 
-.button small {
-  padding-left: 9px;
-  border-left: 1px solid rgba(255, 255, 255, .32);
-  color: rgba(255, 255, 255, .76);
-  font-size: 10px;
-  font-weight: 500;
-  letter-spacing: .03em;
-}
-
-.section {
-  width: min(calc(100% - 48px), var(--max));
-  margin: 0 auto;
-  padding: 116px 0;
-}
-
-.section-narrow { max-width: 900px; }
-
-.section h2 {
-  margin: 0;
-  color: #17213a;
-  font-family: var(--serif);
-  font-size: clamp(2.35rem, 4vw, 4.1rem);
-  font-weight: 500;
-  letter-spacing: -.035em;
-  line-height: 1.08;
-  text-wrap: balance;
-}
-
-.abstract-text {
-  margin: 38px 0 0;
-  color: #354058;
-  font-family: var(--serif);
-  font-size: 21px;
-  line-height: 1.82;
-}
-
-.abstract-text em {
-  color: var(--blue-dark);
-  font-style: normal;
-  font-weight: 600;
-}
-
-.ruled { border-top: 1px solid var(--line); }
-.section-heading { max-width: 790px; margin-bottom: 54px; }
-
-.section-heading > p:last-child {
-  margin: 26px 0 0;
+.btn-muted {
   color: var(--muted);
-  font-size: 18px;
-  line-height: 1.75;
+  cursor: default;
 }
 
-.split-heading {
-  display: grid;
-  max-width: none;
-  grid-template-columns: 1.25fr .75fr;
-  gap: 80px;
-  align-items: end;
+.btn-muted:hover {
+  border-color: var(--border-strong);
+  color: var(--muted);
+  box-shadow: 0 4px 14px rgba(24, 50, 87, .04);
+  transform: none;
 }
 
-.split-heading > p:last-child { margin: 0 0 5px; }
-.paper-figure { margin: 0; }
+.hero-figure,
+.paper-figure {
+  margin: 0;
+}
 
+.hero-figure {
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  box-shadow: 0 18px 50px var(--shadow);
+}
+
+.hero-figure img,
 .paper-figure img {
   width: 100%;
   height: auto;
+  border-radius: 10px;
   background: #fff;
 }
 
-.paper-figure figcaption {
-  margin-top: 16px;
-  color: #737d91;
+[data-theme="dark"] .hero-figure img,
+[data-theme="dark"] .paper-figure img {
+  filter: brightness(.86);
+}
+
+figcaption {
+  max-width: 760px;
+  margin: 12px auto 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.6;
+  text-align: center;
+}
+
+.section {
+  padding: 94px 0 8px;
+}
+
+.section + .section {
+  margin-top: 28px;
+}
+
+.section-heading {
+  margin-bottom: 28px;
+}
+
+.section-heading.split {
+  display: grid;
+  grid-template-columns: 1.05fr .95fr;
+  gap: 54px;
+  align-items: end;
+}
+
+.eyebrow {
+  display: inline-block;
+  margin-bottom: 10px;
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+}
+
+h2 {
+  margin: 0;
+  color: var(--text-strong);
+  font-size: clamp(1.85rem, 4vw, 2.65rem);
+  font-weight: 800;
+  letter-spacing: -.035em;
+  line-height: 1.17;
+}
+
+.section-heading > p,
+.section-heading.split > p,
+.section-note {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.section-heading.split > p {
+  padding-bottom: 4px;
+}
+
+.lead-block {
+  padding: 24px 26px;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius);
+  background: var(--soft);
+}
+
+.lead-block p {
+  margin: 0;
+}
+
+.lead-block p + p {
+  margin-top: 14px;
+}
+
+.lead-block strong {
+  color: var(--accent-strong);
+}
+
+.paper-figure {
+  margin-top: 30px;
+  padding: 13px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: 0 8px 28px rgba(24, 50, 87, .06);
+}
+
+.paper-figure.wide {
+  margin-top: 34px;
+}
+
+.paper-figure.compact {
+  margin-top: 0;
+}
+
+.card-grid {
+  display: grid;
+  gap: 14px;
+  margin-top: 24px;
+}
+
+.card-grid.three {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.feature-card {
+  position: relative;
+  min-height: 180px;
+  padding: 20px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  transition: transform .18s ease, border-color .18s ease, box-shadow .18s ease;
+}
+
+.feature-card::after {
+  content: "";
+  position: absolute;
+  right: -44px;
+  bottom: -56px;
+  width: 130px;
+  height: 130px;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--accent-glow), transparent 67%);
+}
+
+.feature-card:hover {
+  border-color: var(--border-strong);
+  box-shadow: 0 12px 28px var(--shadow);
+  transform: translateY(-2px);
+}
+
+.card-index {
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.feature-card h3,
+.method-flow h3,
+.result-copy h3,
+.resource-card h3,
+.objective-panel h3 {
+  margin: 12px 0 7px;
+  color: var(--text-strong);
+  font-size: 17px;
+  font-weight: 750;
+  line-height: 1.35;
+}
+
+.feature-card p,
+.method-flow p,
+.result-copy p,
+.resource-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.65;
+}
+
+.method-flow {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr auto 1fr;
+  gap: 10px;
+  align-items: stretch;
+}
+
+.method-flow article {
+  display: flex;
+  gap: 13px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--soft);
+}
+
+.flow-num {
+  display: grid;
+  flex: 0 0 28px;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border-radius: 8px;
+  color: #fff;
+  background: linear-gradient(135deg, #0b4aa9, #247df5);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.method-flow h3 {
+  margin-top: 1px;
+}
+
+.flow-arrow {
+  display: grid;
+  place-items: center;
+  color: var(--accent);
+  font-size: 18px;
+}
+
+.objective-panel {
+  display: grid;
+  grid-template-columns: .8fr 1.2fr;
+  gap: 40px;
+  margin-top: 24px;
+  padding: 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  color: var(--text);
+  background:
+    radial-gradient(circle at 0 0, var(--accent-glow), transparent 34%),
+    var(--soft);
+}
+
+.objective-panel h3 {
+  margin-top: 0;
+  font-size: 24px;
+}
+
+.reward-list {
+  display: grid;
+  gap: 0;
+}
+
+.reward-list > div {
+  display: grid;
+  grid-template-columns: 42px 1fr;
+  gap: 12px;
+  padding: 12px 0;
+  border-top: 1px solid var(--border);
+}
+
+.reward-list > div:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.reward-list > div:last-child {
+  padding-bottom: 0;
+}
+
+.reward-list > div > span {
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.reward-list p {
+  margin: 0;
+  color: var(--muted);
   font-size: 13px;
   line-height: 1.6;
 }
 
-.paper-figure figcaption strong { color: #344057; }
-
-.figure-framed {
-  padding: 26px 26px 18px;
-  border: 1px solid var(--line);
-  background: #fbfcfe;
+.reward-list strong {
+  color: var(--text-strong);
 }
 
-.thesis-grid,
-.method-steps {
+.metric-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  margin-top: 70px;
-  border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
+  gap: 12px;
 }
 
-.thesis-grid article,
-.method-steps article {
-  padding: 34px 32px 38px;
-  border-right: 1px solid var(--line);
+.metric-card {
+  min-height: 162px;
+  padding: 22px 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--soft);
 }
 
-.thesis-grid article:first-child,
-.method-steps article:first-child { padding-left: 0; }
-
-.thesis-grid article:last-child,
-.method-steps article:last-child {
-  padding-right: 0;
-  border-right: 0;
-}
-
-.index,
-.step-label {
-  color: var(--blue);
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: .08em;
-  text-transform: uppercase;
-}
-
-.thesis-grid h3,
-.method-steps h3,
-.objective-block h3,
-.table-intro h3,
-.acknowledgments h3 {
-  margin: 12px 0 10px;
-  color: #1b263e;
-  font-family: var(--serif);
-  font-size: 24px;
-  font-weight: 600;
-  line-height: 1.25;
-}
-
-.thesis-grid p,
-.method-steps p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 15px;
-  line-height: 1.7;
-}
-
-.section-tint {
-  position: relative;
-  width: 100%;
-  max-width: none;
-  padding-right: max(24px, calc((100% - var(--max)) / 2));
-  padding-left: max(24px, calc((100% - var(--max)) / 2));
-  background: var(--wash);
-}
-
-.framework-figure {
-  padding: 28px;
-  border: 1px solid #d7deeb;
-  background: #fff;
-}
-
-.method-steps { margin-top: 62px; }
-
-.objective-block {
-  display: grid;
-  grid-template-columns: .72fr 1.28fr;
-  gap: 80px;
-  margin-top: 90px;
-  padding: 52px;
-  color: #e9edfa;
-  background: var(--navy);
-}
-
-.objective-block h3 {
-  margin-top: 0;
-  color: #fff;
-  font-size: 34px;
-}
-
-.objective-block dl { margin: 0; }
-
-.objective-block dl > div {
-  display: grid;
-  grid-template-columns: .8fr 1.2fr;
-  gap: 22px;
-  padding: 20px 0;
-  border-top: 1px solid rgba(255, 255, 255, .15);
-}
-
-.objective-block dl > div:first-child { padding-top: 0; border-top: 0; }
-.objective-block dl > div:last-child { padding-bottom: 0; }
-.objective-block dt { color: #fff; font-weight: 600; }
-
-.objective-block dd {
-  margin: 0;
-  color: #aeb9d1;
-  font-size: 14px;
-  line-height: 1.65;
-}
-
-.result-highlights {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  margin: 10px 0 88px;
-  border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
-}
-
-.result-highlights div {
-  padding: 34px 28px;
-  border-right: 1px solid var(--line);
-}
-
-.result-highlights div:first-child { padding-left: 0; }
-.result-highlights div:last-child { border-right: 0; }
-
-.result-highlights strong {
+.metric-card strong {
   display: block;
-  margin-bottom: 10px;
-  color: var(--blue);
-  font-family: var(--serif);
-  font-size: 44px;
-  font-weight: 500;
-  letter-spacing: -.035em;
+  margin-bottom: 11px;
+  color: var(--accent);
+  font-size: clamp(1.75rem, 4.6vw, 2.45rem);
+  font-weight: 800;
+  letter-spacing: -.04em;
   line-height: 1;
 }
 
-.result-highlights span {
-  color: var(--muted);
+.metric-card span {
+  display: block;
+  color: var(--text-strong);
   font-size: 13px;
-  line-height: 1.55;
+  font-weight: 700;
 }
 
-.table-block { margin-bottom: 90px; }
-
-.table-intro {
-  display: flex;
-  justify-content: space-between;
-  gap: 36px;
-  align-items: end;
-  margin-bottom: 24px;
-}
-
-.table-intro h3 { margin: 0; font-size: 30px; }
-
-.table-intro p {
-  max-width: 560px;
-  margin: 0;
+.metric-card small {
+  display: block;
+  margin-top: 6px;
   color: var(--muted);
-  font-size: 14px;
+  font-size: 11px;
 }
 
-.table-scroll {
+.result-block {
+  margin-top: 28px;
+}
+
+.result-copy {
+  display: grid;
+  grid-template-columns: .7fr 1.3fr;
+  gap: 38px;
+  align-items: end;
+  margin-bottom: 14px;
+}
+
+.result-copy h3 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.table-wrap {
   overflow-x: auto;
-  border-top: 2px solid var(--ink);
-  border-bottom: 1px solid var(--ink);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
 }
 
 table {
   width: 100%;
-  min-width: 820px;
+  min-width: 760px;
   border-collapse: collapse;
   font-family: var(--mono);
-  font-size: 13px;
+  font-size: 11px;
 }
 
-th, td {
-  padding: 14px 13px;
-  border-bottom: 1px solid var(--line);
+th,
+td {
+  padding: 12px 11px;
+  border-bottom: 1px solid var(--border);
   text-align: center;
   white-space: nowrap;
 }
 
 thead th {
-  color: #344057;
-  background: #f8f9fc;
-  font-size: 11px;
+  color: var(--muted);
+  background: var(--soft);
+  font-size: 10px;
   font-weight: 500;
-  letter-spacing: .04em;
+  letter-spacing: .025em;
   text-transform: uppercase;
 }
 
-thead small { color: #788399; font-size: 9px; letter-spacing: 0; }
-tbody th, tbody td:nth-child(2) { text-align: left; }
-tbody th { font-weight: 500; }
-.accent-row { color: var(--blue-dark); background: #f1f5ff; }
-.accent-row td:nth-child(1) { font-weight: 600; }
-tbody tr:last-child td { border-bottom: 0; }
+thead small {
+  font-size: 8px;
+  letter-spacing: 0;
+}
 
-.embedding-grid {
+tbody th,
+tbody td:nth-child(2) {
+  text-align: left;
+}
+
+tbody th {
+  color: var(--text-strong);
+  font-weight: 500;
+}
+
+.highlight-row {
+  color: var(--accent-strong);
+  background: var(--accent-soft);
+}
+
+tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.viz-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 28px;
-}
-
-.embedding-grid figure {
-  padding: 18px 18px 14px;
-  border: 1px solid var(--line);
-  background: #fbfcfe;
-}
-
-.section-dark {
-  width: 100%;
-  max-width: none;
-  padding-right: max(24px, calc((100% - var(--max)) / 2));
-  padding-left: max(24px, calc((100% - var(--max)) / 2));
-  color: #b6c0d5;
-  background: var(--navy);
-}
-
-.section-dark h2 { color: #fff; }
-.section-dark .section-kicker { color: #91adff; }
-
-.citation-grid {
-  display: grid;
-  grid-template-columns: .65fr 1.35fr;
-  gap: 80px;
-}
-
-.citation-grid > div:first-child > p:not(.section-kicker) {
-  max-width: 400px;
-  color: #aeb8cd;
-}
-
-.text-link {
-  display: inline-block;
+  gap: 14px;
   margin-top: 18px;
-  color: #fff;
-  font-size: 14px;
-  font-weight: 600;
-  text-underline-offset: 5px;
 }
 
-.bibtex-wrap { position: relative; }
+.resource-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
 
-pre {
-  min-height: 100%;
-  margin: 0;
-  overflow-x: auto;
-  padding: 34px;
-  border: 1px solid #34415d;
-  color: #dce4f7;
-  background: #0c1427;
+.resource-card {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  text-decoration: none;
+  transition: border-color .18s ease, transform .18s ease, box-shadow .18s ease;
+}
+
+.resource-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 10px 26px var(--shadow);
+  transform: translateY(-2px);
+}
+
+.resource-icon {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border-radius: 10px;
+  color: var(--accent);
+  background: var(--accent-soft);
   font-family: var(--mono);
-  font-size: 12px;
-  line-height: 1.75;
+  font-size: 11px;
+  font-weight: 500;
 }
 
-.copy-button {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-  padding: 7px 10px;
-  border: 1px solid #47546d;
-  border-radius: 3px;
-  color: #c8d2e8;
-  background: #18233b;
-  font: 500 11px var(--sans);
+.resource-card h3 {
+  margin: 0 0 3px;
+  font-size: 14px;
+}
+
+.resource-card p {
+  font-size: 11px;
+}
+
+.resource-arrow {
+  color: var(--muted);
+}
+
+.quickstart,
+.bibtex-card {
+  margin-top: 16px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: #101722;
+}
+
+.quickstart-head,
+.bibtex-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+  padding: 10px 13px;
+  border-bottom: 1px solid #253143;
+  color: #8fa0b5;
+  background: #151e2a;
+  font-family: var(--mono);
+  font-size: 10px;
+}
+
+.copy-btn {
+  padding: 5px 9px;
+  border: 1px solid #34455b;
+  border-radius: 7px;
+  color: #bdc9d8;
+  background: #1c2735;
+  font: 500 10px var(--sans);
   cursor: pointer;
 }
 
-.copy-button:hover { color: #fff; border-color: #6b7892; }
-
-.acknowledgments {
-  display: grid;
-  grid-template-columns: .35fr 1.65fr;
-  gap: 40px;
-  margin-top: 80px;
-  padding-top: 36px;
-  border-top: 1px solid rgba(255, 255, 255, .15);
-}
-
-.acknowledgments h3 {
-  margin: 0;
+.copy-btn:hover {
   color: #fff;
-  font-family: var(--sans);
-  font-size: 14px;
-  text-transform: uppercase;
-  letter-spacing: .06em;
+  border-color: #58718f;
 }
 
-.acknowledgments p { margin: 0; font-size: 14px; }
+pre {
+  margin: 0;
+  overflow-x: auto;
+  padding: 18px;
+  color: #dbe5f2;
+  background: #101722;
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.75;
+}
+
+.faq-list {
+  display: grid;
+  gap: 9px;
+}
+
+details {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--soft);
+}
+
+details[open] {
+  background: var(--surface);
+}
+
+summary {
+  position: relative;
+  padding: 16px 42px 16px 18px;
+  color: var(--text-strong);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  list-style: none;
+}
+
+summary::-webkit-details-marker {
+  display: none;
+}
+
+summary::after {
+  content: "+";
+  position: absolute;
+  top: 50%;
+  right: 17px;
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 18px;
+  transform: translateY(-50%);
+}
+
+details[open] summary::after {
+  content: "−";
+}
+
+details > div {
+  padding: 0 18px 16px;
+}
+
+details p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.bibtex-card {
+  margin-top: 0;
+}
+
+.ack {
+  display: grid;
+  grid-template-columns: 145px 1fr;
+  gap: 24px;
+  margin-top: 17px;
+  padding: 17px 0;
+  border-top: 1px solid var(--border);
+}
+
+.ack strong {
+  color: var(--text-strong);
+  font-size: 12px;
+}
+
+.ack p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+}
 
 footer {
   display: flex;
   justify-content: space-between;
   gap: 30px;
-  padding: 24px max(24px, calc((100% - var(--max)) / 2));
-  border-top: 1px solid #2d3850;
-  color: #8f9bb2;
-  background: #0c1427;
-  font-size: 12px;
+  align-items: flex-end;
+  margin-top: 100px;
+  padding: 26px 0 36px;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 11px;
 }
 
-footer p { margin: 0; }
-footer a { color: #c8d2e8; }
-
-@media (max-width: 900px) {
-  .hero { min-height: auto; }
-  .hero-inner { padding: 80px 0 92px; }
-  .paper-nav { justify-content: center; }
-  h1 { font-size: clamp(2.65rem, 8vw, 4.4rem); }
-  .split-heading,
-  .objective-block,
-  .citation-grid { grid-template-columns: 1fr; gap: 34px; }
-  .split-heading > p:last-child { margin: 0; }
-  .objective-block { padding: 38px; }
-  .table-intro { display: block; }
-  .table-intro p { margin-top: 10px; }
-  .result-highlights strong { font-size: 36px; }
+footer > div {
+  display: grid;
+  gap: 3px;
 }
 
-@media (max-width: 680px) {
-  body { font-size: 16px; }
-  .paper-nav { gap: 20px; padding: 20px 0; }
-  .paper-nav a { font-size: 12px; }
-  .hero-inner { width: min(calc(100% - 32px), 1240px); padding: 62px 0 72px; }
-  h1 { margin-bottom: 32px; font-size: clamp(2.35rem, 11vw, 3.5rem); line-height: 1.02; }
-  .authors { gap: 1px 8px; font-size: 17px; line-height: 1.7; }
-  .affiliations { display: grid; gap: 3px; margin-bottom: 28px; }
-  .hero-actions { align-items: stretch; }
-  .button { flex: 1 1 140px; }
-  .button-primary { flex-basis: 100%; }
-  .section { width: min(calc(100% - 32px), var(--max)); padding: 76px 0; }
-  .section h2 { font-size: 2.45rem; }
-  .abstract-text { margin-top: 28px; font-size: 18px; line-height: 1.72; }
-  .section-tint,
-  .section-dark { width: 100%; padding-right: 16px; padding-left: 16px; }
-  .figure-framed,
-  .framework-figure { padding: 12px; }
-  .thesis-grid,
-  .method-steps,
-  .result-highlights,
-  .embedding-grid { grid-template-columns: 1fr; }
-  .thesis-grid article,
-  .method-steps article,
-  .result-highlights div { padding: 26px 0; border-right: 0; border-bottom: 1px solid var(--line); }
-  .thesis-grid article:last-child,
-  .method-steps article:last-child,
-  .result-highlights div:last-child { border-bottom: 0; }
-  .objective-block { margin-top: 64px; padding: 28px 22px; }
-  .objective-block dl > div { grid-template-columns: 1fr; gap: 6px; }
-  .result-highlights { margin-bottom: 64px; }
-  .embedding-grid { gap: 18px; }
-  .citation-grid { gap: 46px; }
-  pre { padding: 52px 20px 24px; font-size: 10px; }
-  .acknowledgments { grid-template-columns: 1fr; gap: 12px; margin-top: 60px; }
-  footer { display: block; text-align: center; }
-  footer p + p { margin-top: 6px; }
+footer strong {
+  color: var(--text-strong);
+  font-size: 13px;
+}
+
+footer p {
+  margin: 0;
+}
+
+footer a {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+footer a:hover {
+  color: var(--accent);
+}
+
+.reveal {
+  opacity: 0;
+  transform: translateY(14px);
+  transition: opacity .55s ease, transform .55s cubic-bezier(.2, .7, .2, 1);
+}
+
+.reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 760px) {
+  .topbar {
+    grid-template-columns: auto 1fr auto;
+  }
+
+  .nav-links {
+    display: none;
+  }
+
+  .hero {
+    padding-top: 78px;
+  }
+
+  .section {
+    padding-top: 72px;
+  }
+
+  .section-heading.split,
+  .result-copy,
+  .objective-panel {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .method-flow {
+    grid-template-columns: 1fr;
+  }
+
+  .flow-arrow {
+    height: 20px;
+    transform: rotate(90deg);
+  }
+
+  .card-grid.three,
+  .metric-grid,
+  .resource-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .feature-card,
+  .metric-card {
+    min-height: auto;
+  }
+
+  .viz-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ack {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
+}
+
+@media (max-width: 520px) {
+  .page-shell {
+    width: min(calc(100% - 24px), var(--max));
+  }
+
+  .topbar {
+    top: 8px;
+    margin-top: 8px;
+    padding: 8px 9px 8px 11px;
+  }
+
+  h1 {
+    font-size: clamp(2.25rem, 11.5vw, 3.25rem);
+  }
+
+  .subtitle {
+    font-size: .98rem;
+  }
+
+  .authors {
+    font-size: 13px;
+  }
+
+  .affiliations {
+    display: grid;
+    gap: 2px;
+  }
+
+  .hero-actions {
+    align-items: stretch;
+  }
+
+  .btn {
+    flex: 1 1 135px;
+  }
+
+  .btn-muted {
+    flex-basis: 100%;
+  }
+
+  .hero-figure {
+    padding: 8px;
+    border-radius: 12px;
+  }
+
+  .lead-block,
+  .feature-card,
+  .metric-card,
+  .resource-card,
+  .objective-panel {
+    padding: 17px;
+  }
+
+  .paper-figure {
+    padding: 7px;
+  }
+
+  .section {
+    padding-top: 62px;
+  }
+
+  pre {
+    font-size: 9.5px;
+  }
+
+  footer {
+    display: block;
+    text-align: center;
+  }
+
+  footer > div {
+    justify-items: center;
+    margin-bottom: 8px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  html { scroll-behavior: auto; }
-  *, *::before, *::after { transition-duration: .01ms !important; }
+  html {
+    scroll-behavior: auto;
+  }
+
+  .ambient {
+    animation: none;
+  }
+
+  .reveal {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+
+  *,
+  *::before,
+  *::after {
+    transition-duration: .01ms !important;
+  }
 }


### PR DESCRIPTION
## Summary
- redesigns the PGPO project page with a compact, publication-focused layout inspired by modern research project sites
- adds a stronger hero section, venue badges, resource pills, TL;DR cards, method flow, result highlights, resource cards, FAQ, and citation block
- adds light/dark theme switching and subtle scroll reveal effects
- preserves the existing PGPO figures, metrics, authors, acknowledgments, and project links
- improves social/SEO metadata for sharing

## Scope
Only `docs/index.html` and `docs/style.css` are changed; research code and assets are untouched.

## Notes
The paper button intentionally remains `arXiv soon` until the public preprint URL is available.