### PR TITLE
Refine PGPO page to match compact academic project-page style

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script>
     (function () {
-      var saved = localStorage.getItem('pgpo-theme');
-      if (saved === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
+      var t = localStorage.getItem('pgpo-theme');
+      if (t === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
     })();
   </script>
 
-  <title>PGPO — Privacy-Preserving LLM-Enhanced Recommendation</title>
-  <meta name="description" content="PGPO is an EMNLP 2026 Main Conference work on topology-aware semantic obfuscation for privacy-preserving LLM-enhanced recommendation.">
+  <title>PGPO: Prototype-Guided Progressive Obfuscation for Privacy-Preserving LLM-Enhanced Recommendation</title>
+  <meta name="description" content="PGPO, accepted to EMNLP 2026 Main Conference, learns topology-aware semantic obfuscation for privacy-preserving LLM-enhanced recommendation.">
   <meta name="author" content="Shengxiang Lin, Jiajie Su, Pengyang Zhou, Xiang Chen, Xiaolin Zheng, Feng Tian, Chaochao Chen">
   <meta name="robots" content="index,follow">
   <link rel="canonical" href="https://shengxiang-lin.github.io/PGPO/">
@@ -28,442 +28,317 @@
   <meta name="citation_conference_title" content="Proceedings of the 2026 Conference on Empirical Methods in Natural Language Processing">
 
   <meta property="og:type" content="article">
-  <meta property="og:title" content="PGPO — Prototype-Guided Progressive Obfuscation">
-  <meta property="og:description" content="Protect textual privacy in LLM-enhanced recommendation while preserving relational fidelity. EMNLP 2026 Main Conference.">
+  <meta property="og:title" content="PGPO — EMNLP 2026 Main">
+  <meta property="og:description" content="Topology-aware semantic obfuscation for privacy-preserving LLM-enhanced recommendation.">
   <meta property="og:url" content="https://shengxiang-lin.github.io/PGPO/">
   <meta property="og:image" content="https://raw.githubusercontent.com/Shengxiang-Lin/PGPO/main/docs/assets/framework.webp">
-  <meta property="og:site_name" content="PGPO">
 
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="PGPO — Privacy-Preserving LLM-Enhanced Recommendation">
-  <meta name="twitter:description" content="Prototype-guided GRPO for topology-aware semantic obfuscation. EMNLP 2026 Main Conference.">
+  <meta name="twitter:title" content="PGPO — EMNLP 2026 Main">
+  <meta name="twitter:description" content="Prototype-guided GRPO for privacy-preserving LLM-enhanced recommendation.">
   <meta name="twitter:image" content="https://raw.githubusercontent.com/Shengxiang-Lin/PGPO/main/docs/assets/framework.webp">
 
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 
 <body>
-  <div class="ambient ambient-one" aria-hidden="true"></div>
-  <div class="ambient ambient-two" aria-hidden="true"></div>
+  <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle light/dark theme" title="Toggle theme"></button>
 
-  <div class="page-shell">
-    <nav class="topbar" aria-label="Primary navigation">
-      <a class="brand" href="#top" aria-label="PGPO home">
-        <span class="brand-mark">P</span>
-        <span>PGPO</span>
-      </a>
+  <div class="wrap">
+    <header>
+      <h1>PGPO: Prototype-Guided Progressive Obfuscation for Privacy-Preserving LLM-Enhanced Recommendation</h1>
 
-      <div class="nav-links">
-        <a href="#overview">Overview</a>
-        <a href="#method">Method</a>
-        <a href="#results">Results</a>
-        <a href="#resources">Resources</a>
+      <p class="subtitle">
+        Protecting textual privacy in LLM-enhanced recommendation while preserving the relational
+        structure that downstream recommenders rely on.
+      </p>
+
+      <div class="venues" aria-label="Publication venue">
+        <span class="venue">EMNLP 2026 · Main Conference</span>
+        <span class="venue secondary">Open Source</span>
       </div>
 
-      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle color theme"></button>
-    </nav>
+      <p class="authors">
+        <span class="au"><a href="https://Shengxiang-Lin.github.io/">Shengxiang Lin</a><sup>1</sup></span>,
+        <span class="au"><a href="https://scholar.google.com/citations?hl=zh-CN&amp;user=tn09CCIAAAAJ&amp;view_op=list_works&amp;sortby=pubdate">Jiajie Su</a><sup>1</sup></span>,
+        <span class="au"><a href="https://scholar.google.com/citations?hl=zh-CN&amp;user=3LnDqE4AAAAJ&amp;view_op=list_works&amp;sortby=pubdate">Pengyang Zhou</a><sup>1</sup></span>,
+        <span class="au"><a href="https://scholar.google.com/citations?user=ZMdsjDUAAAAJ&amp;hl=zh-CN&amp;oi=sra">Xiang Chen</a><sup>1</sup></span>,
+        <span class="au"><a href="https://person.zju.edu.cn/xlzheng#0">Xiaolin Zheng</a><sup>1,*</sup></span>,
+        <span class="au"><a href="https://www.xjtu.edu.cn/jsnr.jsp?wbtreeid=1632&amp;wbwbxjtuteacherid=1473">Feng Tian</a><sup>2,*</sup></span>,
+        <span class="au"><a href="https://person.zju.edu.cn/zjuccc">Chaochao Chen</a><sup>1</sup></span>
+      </p>
 
-    <main id="top">
-      <header class="hero">
-        <div class="venue-row">
-          <span class="venue">EMNLP 2026 · Main Conference</span>
-          <span class="venue venue-soft">Open Source</span>
-        </div>
+      <p class="legend">
+        <sup>1</sup>&nbsp;Zhejiang University
+        &nbsp;·&nbsp;
+        <sup>2</sup>&nbsp;Xi'an Jiaotong University
+        &nbsp;·&nbsp;
+        <sup>*</sup>&nbsp;Corresponding authors
+      </p>
 
-        <h1>
-          <span class="title-accent">PGPO:</span>
-          Prototype-Guided Progressive Obfuscation for Privacy-Preserving LLM-Enhanced Recommendation
-        </h1>
+      <nav class="btns" aria-label="Project links">
+        <span class="btn disabled" title="The arXiv link will be added once the preprint is public">
+          <svg class="ic" viewBox="0 0 24 24" aria-hidden="true"><path d="M6.8 2.8h7l3.4 3.4V21.2H6.8zM13.8 2.8v4h4M9 12h6M9 15h6M9 18h4.5"/></svg>
+          Paper · Coming Soon
+        </span>
 
-        <p class="subtitle">
-          Topology-aware semantic obfuscation that protects textual privacy while preserving the
-          relational structure recommendation systems actually need.
-        </p>
+        <a class="btn" href="https://github.com/Shengxiang-Lin/PGPO">
+          <svg class="ic" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" stroke="none" d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.3.8-.6v-2c-3.2.7-3.9-1.4-3.9-1.4-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.7-1.6-2.6-.3-5.3-1.3-5.3-5.8 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17 4.6 18 4.9 18 4.9c.6 1.6.2 2.8.1 3.1.7.8 1.2 1.8 1.2 3.1 0 4.5-2.7 5.5-5.3 5.8.4.3.8 1 .8 2.1v3.1c0 .3.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/></svg>
+          Code
+        </a>
 
-        <div class="authors" aria-label="Authors">
-          <a href="https://Shengxiang-Lin.github.io/">Shengxiang Lin</a><sup>1</sup>,
-          <a href="https://scholar.google.com/citations?hl=zh-CN&amp;user=tn09CCIAAAAJ&amp;view_op=list_works&amp;sortby=pubdate">Jiajie Su</a><sup>1</sup>,
-          <a href="https://scholar.google.com/citations?hl=zh-CN&amp;user=3LnDqE4AAAAJ&amp;view_op=list_works&amp;sortby=pubdate">Pengyang Zhou</a><sup>1</sup>,
-          <a href="https://scholar.google.com/citations?user=ZMdsjDUAAAAJ&amp;hl=zh-CN&amp;oi=sra">Xiang Chen</a><sup>1</sup>,
-          <a href="https://person.zju.edu.cn/xlzheng#0">Xiaolin Zheng</a><sup>1,*</sup>,
-          <a href="https://www.xjtu.edu.cn/jsnr.jsp?wbtreeid=1632&amp;wbwbxjtuteacherid=1473">Feng Tian</a><sup>2,*</sup>,
-          <a href="https://person.zju.edu.cn/zjuccc">Chaochao Chen</a><sup>1</sup>
-        </div>
+        <a class="btn" href="https://huggingface.co/Shengxiang-Lin/PGPO">
+          <svg class="ic" viewBox="0 0 24 24" aria-hidden="true"><ellipse cx="12" cy="5.6" rx="7" ry="2.6"/><path d="M5 5.6v12.8c0 1.44 3.13 2.6 7 2.6s7-1.16 7-2.6V5.6M5 12c0 1.44 3.13 2.6 7 2.6s7-1.16 7-2.6"/></svg>
+          Models
+        </a>
 
-        <div class="affiliations">
-          <span><sup>1</sup> Zhejiang University</span>
-          <span><sup>2</sup> Xi'an Jiaotong University</span>
-          <span><sup>*</sup> Corresponding authors</span>
-        </div>
+        <a class="btn" href="https://github.com/Shengxiang-Lin/PGPO/tree/main/evaluate">
+          <svg class="ic" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 19V9M10 19V5M16 19v-7M22 19V2"/></svg>
+          Evaluation
+        </a>
+      </nav>
 
-        <div class="hero-actions" aria-label="Project links">
-          <span class="btn btn-muted" aria-label="Paper coming soon">
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6.5 2.8h8l3 3v15.4h-11zM14.5 2.8v4h4M9 11h6M9 14.5h6M9 18h4"/></svg>
-            Paper · arXiv soon
-          </span>
-
-          <a class="btn btn-primary" href="https://github.com/Shengxiang-Lin/PGPO">
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" stroke="none" d="M12 .7A11.3 11.3 0 0 0 8.4 22.8c.6.1.8-.3.8-.6v-2.1c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.4-1.3-5.4-5.9 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.3 11.3 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.6 1.7.2 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.4 5.9.4.4.8 1.1.8 2.1v3.2c0 .3.2.7.8.6A11.3 11.3 0 0 0 12 .7z"/></svg>
-            Code
-          </a>
-
-          <a class="btn" href="https://huggingface.co/Shengxiang-Lin/PGPO">
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.3 8.7c0-3 2-5.2 4.7-5.2s4.7 2.2 4.7 5.2v3.5c0 4-2 7-4.7 8.3-2.7-1.3-4.7-4.3-4.7-8.3zM9.7 9.2h.1M14.2 9.2h.1M9.7 13c1.5 1.2 3.1 1.2 4.6 0"/></svg>
-            Models
-          </a>
-
-          <a class="btn" href="https://github.com/Shengxiang-Lin/PGPO/tree/main/evaluate">
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 19V9M10 19V5M16 19v-7M22 19V2"/></svg>
-            Evaluation
-          </a>
-        </div>
-      </header>
-
-      <figure class="hero-figure reveal">
-        <img src="assets/framework.webp" alt="PGPO framework: prototype-aware graph construction, GRPO-based anchor exploration, and progressive expansion">
+      <figure class="hero-figure">
+        <img src="assets/framework.webp" alt="Overview of the PGPO framework" width="2400" height="1100" decoding="async">
         <figcaption>
-          PGPO learns privacy-preserving obfuscation anchors for structurally influential prototype words,
-          then propagates them through a vocabulary-level semantic graph.
+          PGPO identifies high-influence prototype words, learns privacy-preserving obfuscation anchors with GRPO,
+          and progressively propagates them through a static vocabulary-level semantic graph.
         </figcaption>
       </figure>
+    </header>
 
-      <section id="overview" class="section reveal">
-        <div class="section-heading">
-          <span class="eyebrow">Overview · TL;DR</span>
-          <h2>Privacy protection should preserve relationships, not just words.</h2>
-        </div>
+    <section id="overview" class="animate-on-scroll">
+      <h2>Overview (TL;DR)</h2>
 
-        <div class="lead-block">
-          <p>
-            LLM-enhanced recommender systems encode item side information into semantic representations,
-            but those representations can expose sensitive textual attributes through inversion and
-            re-identification attacks. Conventional token-level perturbation can hide content while
-            simultaneously destroying the geometry that downstream recommendation relies on.
-          </p>
-          <p>
-            <strong>PGPO introduces relational fidelity as the central design principle:</strong>
-            move each protected representation away from its source while preserving relative semantic
-            structure across items.
-          </p>
-        </div>
+      <p class="lead">
+        LLM-enhanced recommender systems can encode item side information into semantic representations,
+        but these representations may leak sensitive textual attributes through inversion attacks.
+        <strong>PGPO</strong> protects textual semantics without discarding the relational geometry needed
+        for recommendation.
+      </p>
 
-        <figure class="paper-figure">
-          <img src="assets/motivation.webp" alt="Motivation for relational fidelity in privacy-preserving recommendation">
-          <figcaption>
-            Relational fidelity: shift exposed semantics for privacy while preserving neighborhood
-            relations for recommendation utility.
-          </figcaption>
-        </figure>
+      <p>
+        The central idea is <strong>relational fidelity</strong>: protected representations should move away
+        from their original textual sources while preserving relative semantic relationships among items.
+        PGPO realizes this idea through a prototype-aware semantic graph, GRPO-based anchor exploration,
+        and progressive graph-guided expansion.
+      </p>
 
-        <div class="card-grid three">
-          <article class="feature-card">
-            <span class="card-index">01</span>
-            <h3>Prototype-aware graph</h3>
-            <p>Find structurally influential vocabulary prototypes and precompute semantic neighborhoods.</p>
-          </article>
+      <p>The paper makes three main contributions:</p>
 
-          <article class="feature-card">
-            <span class="card-index">02</span>
-            <h3>GRPO exploration</h3>
-            <p>Learn obfuscation anchors that balance individual semantic shift and relational consistency.</p>
-          </article>
+      <ol class="contrib">
+        <li>Introduces <strong>relational fidelity</strong> as a privacy–utility objective for LLM-enhanced recommendation.</li>
+        <li>Proposes a <strong>prototype-guided GRPO</strong> procedure that concentrates optimization on structurally influential vocabulary anchors.</li>
+        <li>Provides an end-to-end evaluation pipeline spanning recommendation utility, embedding inversion, and white-box source re-identification.</li>
+      </ol>
+    </section>
 
-          <article class="feature-card">
-            <span class="card-index">03</span>
-            <h3>Progressive expansion</h3>
-            <p>Propagate reliable prototype mappings to the rest of the vocabulary using finalized neighbors.</p>
-          </article>
-        </div>
-      </section>
+    <section id="abstract" class="animate-on-scroll">
+      <h2>Abstract</h2>
+      <div class="block abstract">
+        <p>
+          LLM-enhanced recommender systems encode item side information into semantic embeddings, but these
+          embeddings may leak sensitive textual attributes through inversion attacks. Existing input-side
+          defenses rely on trusted collection or local token perturbation, often disrupting the inter-item
+          semantic topology needed for recommendation. We introduce <strong>relational fidelity</strong> as the
+          key objective: semantic shift should be large enough for privacy while relative item relations remain
+          stable for utility. Based on this principle, we propose <strong>PGPO</strong>, which learns topology-aware
+          obfuscation anchors for high-influence prototype words and propagates them through a static semantic graph.
+          PGPO is optimized with GRPO using individual dissimilarity, structural consistency, and semantic constraint
+          rewards. Experiments on MovieLens-1M and Amazon-Book show strong inversion defense with recommendation
+          performance close to the unprotected upper bound.
+        </p>
+      </div>
+    </section>
 
-      <section id="method" class="section reveal">
-        <div class="section-heading split">
-          <div>
-            <span class="eyebrow">Method</span>
-            <h2>Prototype-guided progressive obfuscation.</h2>
-          </div>
-          <p>
-            Instead of optimizing every word independently, PGPO first learns a compact set of trusted
-            obfuscation anchors and then expands from the semantic backbone outward.
-          </p>
-        </div>
+    <section id="motivation" class="animate-on-scroll">
+      <h2>Why Relational Fidelity?</h2>
+      <p>
+        Protecting an item independently is not enough. Recommendation quality depends on how items relate to one
+        another in semantic space. A useful privacy transformation therefore needs to change exposed semantics
+        <em>without destroying the neighborhood structure that carries recommendation signal</em>.
+      </p>
 
-        <div class="method-flow">
-          <article>
-            <span class="flow-num">1</span>
-            <div>
-              <h3>Construct</h3>
-              <p>Build a static semantic graph and identify high-influence prototype words.</p>
-            </div>
-          </article>
-          <div class="flow-arrow" aria-hidden="true">→</div>
-          <article>
-            <span class="flow-num">2</span>
-            <div>
-              <h3>Explore</h3>
-              <p>Use GRPO to search for privacy-preserving variants for prototype anchors.</p>
-            </div>
-          </article>
-          <div class="flow-arrow" aria-hidden="true">→</div>
-          <article>
-            <span class="flow-num">3</span>
-            <div>
-              <h3>Expand</h3>
-              <p>Generate non-prototype variants conditioned on finalized neighboring mappings.</p>
-            </div>
-          </article>
-        </div>
+      <figure>
+        <img src="assets/motivation.webp" alt="Comparison between local perturbation and PGPO relational-fidelity obfuscation" width="1780" height="720" loading="lazy">
+        <figcaption>
+          PGPO shifts individual semantics for privacy while preserving relative item relations for downstream recommendation.
+        </figcaption>
+      </figure>
+    </section>
 
-        <figure class="paper-figure wide">
-          <img src="assets/framework.webp" alt="Detailed PGPO framework">
-          <figcaption>
-            The full PGPO pipeline combines graph construction, prototype extraction, GRPO-based exploration,
-            cached neighborhood anchors, and progressive generation.
-          </figcaption>
-        </figure>
+    <section id="method" class="animate-on-scroll">
+      <h2>How It Works</h2>
 
-        <div class="objective-panel">
-          <div>
-            <span class="eyebrow">Optimization</span>
-            <h3>Three signals, one privacy–utility objective.</h3>
-          </div>
-          <div class="reward-list">
-            <div>
-              <span>R₁</span>
-              <p><strong>Individual dissimilarity</strong><br>Push each variant away from its original semantic source.</p>
-            </div>
-            <div>
-              <span>R₂</span>
-              <p><strong>Structural consistency</strong><br>Preserve relative topology among neighboring vocabulary items.</p>
-            </div>
-            <div>
-              <span>R₃</span>
-              <p><strong>Semantic constraint</strong><br>Keep exploration valid and useful rather than arbitrarily destructive.</p>
-            </div>
-          </div>
-        </div>
-      </section>
+      <div class="finding">
+        <h3><span class="num">1.</span>Build a prototype-aware semantic graph</h3>
+        <p>
+          PGPO constructs a static vocabulary-level semantic graph and identifies high-influence prototype words
+          that capture the structural backbone of the vocabulary.
+        </p>
+      </div>
 
-      <section id="results" class="section reveal">
-        <div class="section-heading">
-          <span class="eyebrow">Results</span>
-          <h2>Strong inversion resistance with near-upper-bound recommendation utility.</h2>
-        </div>
+      <div class="finding">
+        <h3><span class="num">2.</span>Learn obfuscation anchors with GRPO</h3>
+        <p>
+          For prototype words, PGPO explores candidate variants under three complementary rewards:
+          <strong class="k">individual dissimilarity</strong>, <strong class="k">structural consistency</strong>,
+          and <strong class="k">semantic constraint</strong>.
+        </p>
+      </div>
 
-        <div class="metric-grid">
-          <article class="metric-card">
-            <strong>51.8%</strong>
-            <span>lower exact-match inversion</span>
-            <small>MovieLens-1M</small>
-          </article>
-          <article class="metric-card">
-            <strong>68.2%</strong>
-            <span>lower exact-match inversion</span>
-            <small>Amazon-Book</small>
-          </article>
-          <article class="metric-card">
-            <strong>≈ upper bound</strong>
-            <span>recommendation utility</span>
-            <small>across multiple model families</small>
-          </article>
-        </div>
+      <div class="finding">
+        <h3><span class="num">3.</span>Expand progressively through the graph</h3>
+        <p>
+          Once reliable prototype mappings are finalized, non-prototype words are generated while conditioning on
+          nearby finalized mappings. This transfers the learned obfuscation structure from the semantic core to the
+          rest of the vocabulary.
+        </p>
+      </div>
 
-        <div class="result-block">
-          <div class="result-copy">
-            <h3>Recommendation performance</h3>
-            <p>
-              PGPO stays close to the unprotected description upper bound across sequential, graph,
-              multimodal, and LLM-based recommenders.
-            </p>
-          </div>
+      <div class="modelset">
+        <b>Core pipeline:</b> semantic graph construction · prototype extraction · GRPO training · context-aware
+        generation cache · progressive expansion · downstream privacy/utility evaluation.
+      </div>
+    </section>
 
-          <div class="table-wrap" role="region" aria-label="Recommendation results" tabindex="0">
-            <table>
-              <thead>
-                <tr>
-                  <th>Dataset</th>
-                  <th>Input</th>
-                  <th>SASRec<br><small>HR@10</small></th>
-                  <th>LightGCN<br><small>HR@10</small></th>
-                  <th>FREEDOM<br><small>HR@10</small></th>
-                  <th>LightGT<br><small>HR@10</small></th>
-                  <th>TALLRec<br><small>AUC</small></th>
-                  <th>LLaRA<br><small>HR@1</small></th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <th rowspan="2">MovieLens-1M</th>
-                  <td>Description</td><td>.1129</td><td>.0850</td><td>.0840</td><td>.0847</td><td>.6990</td><td>.2454</td>
-                </tr>
-                <tr class="highlight-row">
-                  <td>PGPO</td><td>.1133</td><td>.0848</td><td>.0842</td><td>.0839</td><td>.6978</td><td>.2451</td>
-                </tr>
-                <tr>
-                  <th rowspan="2">Amazon-Book</th>
-                  <td>Description</td><td>.1843</td><td>.0926</td><td>.0762</td><td>.0929</td><td>.7983</td><td>.5348</td>
-                </tr>
-                <tr class="highlight-row">
-                  <td>PGPO</td><td>.1846</td><td>.0920</td><td>.0753</td><td>.0930</td><td>.7979</td><td>.5257</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
+    <section id="results" class="animate-on-scroll">
+      <h2>Key Results</h2>
 
-        <div class="viz-grid">
-          <figure class="paper-figure compact">
-            <img src="assets/tsne-movielens.webp" alt="t-SNE visualization on MovieLens-1M">
-            <figcaption><strong>MovieLens-1M.</strong> Protected embeddings shift semantics while maintaining relational organization.</figcaption>
-          </figure>
-          <figure class="paper-figure compact">
-            <img src="assets/tsne-amazon.webp" alt="t-SNE visualization on Amazon-Book">
-            <figcaption><strong>Amazon-Book.</strong> PGPO preserves useful global structure under a denser vocabulary.</figcaption>
-          </figure>
-        </div>
-      </section>
+      <div class="finding">
+        <h3><span class="num">1.</span>Substantially stronger inversion resistance</h3>
+        <p>
+          PGPO reduces exact-match inversion by <strong class="k">51.8%</strong> on MovieLens-1M and
+          <strong class="k">68.2%</strong> on Amazon-Book relative to the unprotected textual representations.
+        </p>
+      </div>
 
-      <section id="resources" class="section reveal">
-        <div class="section-heading split">
-          <div>
-            <span class="eyebrow">Open source</span>
-            <h2>Reproduce, evaluate, extend.</h2>
-          </div>
-          <p>
-            The repository includes data preparation, semantic graph construction, prototype extraction,
-            GRPO training, generation, recommendation evaluation, and privacy-attack evaluation.
-          </p>
-        </div>
+      <div class="finding">
+        <h3><span class="num">2.</span>Recommendation utility remains close to the upper bound</h3>
+        <p>
+          Across sequential, graph-based, multimodal, and LLM-based recommenders, PGPO stays close to the
+          performance obtained from original item descriptions while providing substantially stronger privacy.
+        </p>
+      </div>
 
-        <div class="resource-grid">
-          <a class="resource-card" href="https://github.com/Shengxiang-Lin/PGPO">
-            <span class="resource-icon">⌘</span>
-            <div>
-              <h3>Code</h3>
-              <p>End-to-end training and evaluation pipeline.</p>
-            </div>
-            <span class="resource-arrow">↗</span>
-          </a>
+      <div class="finding">
+        <h3><span class="num">3.</span>The protected space retains useful global structure</h3>
+        <p>
+          t-SNE visualizations show that PGPO changes exposed semantics while preserving recognizable relational
+          organization in both MovieLens-1M and Amazon-Book.
+        </p>
+      </div>
+    </section>
 
-          <a class="resource-card" href="https://huggingface.co/Shengxiang-Lin/PGPO">
-            <span class="resource-icon">HF</span>
-            <div>
-              <h3>Model weights</h3>
-              <p>Released checkpoints for MovieLens-1M and Amazon-Book.</p>
-            </div>
-            <span class="resource-arrow">↗</span>
-          </a>
+    <section id="table" class="animate-on-scroll">
+      <h2>Recommendation Performance</h2>
+      <p>
+        Representative results across multiple recommender families. <strong>Description</strong> denotes the
+        unprotected textual upper bound.
+      </p>
 
-          <a class="resource-card" href="https://github.com/Shengxiang-Lin/PGPO/tree/main/evaluate">
-            <span class="resource-icon">∑</span>
-            <div>
-              <h3>Evaluation</h3>
-              <p>Recommendation, inversion, and white-box re-identification.</p>
-            </div>
-            <span class="resource-arrow">↗</span>
-          </a>
-        </div>
+      <div class="table-scroll" role="region" aria-label="Recommendation results" tabindex="0">
+        <table>
+          <thead>
+            <tr>
+              <th>Dataset</th>
+              <th>Input</th>
+              <th>SASRec<br><small>HR@10</small></th>
+              <th>LightGCN<br><small>HR@10</small></th>
+              <th>FREEDOM<br><small>HR@10</small></th>
+              <th>LightGT<br><small>HR@10</small></th>
+              <th>TALLRec<br><small>AUC</small></th>
+              <th>LLaRA<br><small>HR@1</small></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th rowspan="2">MovieLens-1M</th>
+              <td>Description</td><td>.1129</td><td>.0850</td><td>.0840</td><td>.0847</td><td>.6990</td><td>.2454</td>
+            </tr>
+            <tr class="accent-row">
+              <td>PGPO</td><td>.1133</td><td>.0848</td><td>.0842</td><td>.0839</td><td>.6978</td><td>.2451</td>
+            </tr>
+            <tr>
+              <th rowspan="2">Amazon-Book</th>
+              <td>Description</td><td>.1843</td><td>.0926</td><td>.0762</td><td>.0929</td><td>.7983</td><td>.5348</td>
+            </tr>
+            <tr class="accent-row">
+              <td>PGPO</td><td>.1846</td><td>.0920</td><td>.0753</td><td>.0930</td><td>.7979</td><td>.5257</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
 
-        <div class="quickstart">
-          <div class="quickstart-head">
-            <span>Quick start</span>
-            <button type="button" class="copy-btn" data-copy-target="quickstart-code">Copy</button>
-          </div>
-          <pre id="quickstart-code"><code>git clone https://github.com/Shengxiang-Lin/PGPO.git
+    <section id="visualization" class="animate-on-scroll">
+      <h2>Representation Analysis</h2>
+
+      <figure>
+        <img src="assets/tsne-movielens.webp" alt="t-SNE visualization of original and obfuscated representations on MovieLens-1M" width="1200" height="860" loading="lazy">
+        <figcaption><strong>MovieLens-1M.</strong> PGPO shifts exposed semantics while retaining a coherent relational layout.</figcaption>
+      </figure>
+
+      <figure>
+        <img src="assets/tsne-amazon.webp" alt="t-SNE visualization of original and obfuscated representations on Amazon-Book" width="1200" height="860" loading="lazy">
+        <figcaption><strong>Amazon-Book.</strong> The protected representation space retains useful large-scale structure.</figcaption>
+      </figure>
+    </section>
+
+    <section id="resources" class="animate-on-scroll">
+      <h2>Resources</h2>
+
+      <ul class="reslist">
+        <li><a href="https://github.com/Shengxiang-Lin/PGPO">GitHub repository</a> — full training and evaluation pipeline.</li>
+        <li><a href="https://huggingface.co/Shengxiang-Lin/PGPO">Hugging Face models</a> — released model weights for MovieLens-1M and Amazon-Book.</li>
+        <li><a href="https://github.com/Shengxiang-Lin/PGPO/tree/main/evaluate">Evaluation suite</a> — recommendation, embedding inversion, and white-box source re-identification.</li>
+        <li>arXiv preprint — coming soon.</li>
+      </ul>
+
+      <nav class="btns" aria-label="Project links repeated">
+        <a class="btn" href="https://github.com/Shengxiang-Lin/PGPO">Code</a>
+        <a class="btn" href="https://huggingface.co/Shengxiang-Lin/PGPO">Models</a>
+        <a class="btn" href="https://github.com/Shengxiang-Lin/PGPO/tree/main/evaluate">Evaluation</a>
+      </nav>
+    </section>
+
+    <section id="quickstart" class="animate-on-scroll">
+      <h2>Quick Start</h2>
+      <pre><code>git clone https://github.com/Shengxiang-Lin/PGPO.git
 cd PGPO
+
 conda create -n pgpo python=3.10 -y
 conda activate pgpo
 pip install -r requirements.txt</code></pre>
-        </div>
-      </section>
+    </section>
 
-      <section id="faq" class="section reveal">
-        <div class="section-heading">
-          <span class="eyebrow">FAQ</span>
-          <h2>What PGPO is designed to solve.</h2>
-        </div>
+    <section id="bibtex" class="animate-on-scroll">
+      <h2>BibTeX</h2>
+      <div class="bibhead">
+        <span>EMNLP 2026 citation · arXiv metadata forthcoming</span>
+        <button class="copy" id="copybtn" type="button">Copy BibTeX</button>
+      </div>
+      <pre id="bibtex-code">@inproceedings{lin2026pgpo,
+  title={{PGPO}: Prototype-Guided Progressive Obfuscation for Privacy-Preserving LLM-Enhanced Recommendation},
+  author={Lin, Shengxiang and Su, Jiajie and Zhou, Pengyang and Chen, Xiang and Zheng, Xiaolin and Tian, Feng and Chen, Chaochao},
+  booktitle={Proceedings of the 2026 Conference on Empirical Methods in Natural Language Processing},
+  year={2026},
+  note={To appear}
+}</pre>
+    </section>
 
-        <div class="faq-list">
-          <details>
-            <summary>Why not simply perturb item text or embeddings independently?</summary>
-            <div>
-              <p>
-                Independent perturbation can hide local semantics but may destroy the relative geometry among
-                items. PGPO explicitly optimizes relational fidelity so privacy protection preserves signals
-                needed by downstream recommendation.
-              </p>
-            </div>
-          </details>
-
-          <details>
-            <summary>Why use prototypes?</summary>
-            <div>
-              <p>
-                High-influence prototype words capture the semantic graph's structural backbone. Learning
-                reliable anchors there first makes subsequent expansion more stable and computationally focused.
-              </p>
-            </div>
-          </details>
-
-          <details>
-            <summary>What does the repository evaluate?</summary>
-            <div>
-              <p>
-                It includes recommendation backends, semantic and generation-quality analysis, embedding
-                inversion, and white-box source re-identification, enabling privacy and utility to be measured
-                together.
-              </p>
-            </div>
-          </details>
-
-          <details>
-            <summary>Which datasets are supported?</summary>
-            <div>
-              <p>MovieLens-1M and Amazon-Book are included in the released pipeline.</p>
-            </div>
-          </details>
-        </div>
-      </section>
-
-      <section id="citation" class="section reveal">
-        <div class="section-heading">
-          <span class="eyebrow">Citation</span>
-          <h2>Cite PGPO</h2>
-          <p class="section-note">The arXiv identifier will be added once the preprint is publicly available.</p>
-        </div>
-
-        <div class="bibtex-card">
-          <div class="bibtex-head">
-            <span>EMNLP 2026</span>
-            <button type="button" class="copy-btn" data-copy-target="bibtex-code">Copy BibTeX</button>
-          </div>
-          <pre id="bibtex-code"><code>@inproceedings{lin2026pgpo,
-  title     = {PGPO: Prototype-Guided Progressive Obfuscation for Privacy-Preserving LLM-Enhanced Recommendation},
-  author    = {Lin, Shengxiang and Su, Jiajie and Zhou, Pengyang and Chen, Xiang and Zheng, Xiaolin and Tian, Feng and Chen, Chaochao},
-  booktitle = {Proceedings of EMNLP},
-  year      = {2026}
-}</code></pre>
-        </div>
-
-        <div class="ack">
-          <strong>Acknowledgments</strong>
-          <p>This work was supported by the National Natural Science Foundation of China (Nos. 72192823, 62177038, and 62522217).</p>
-        </div>
-      </section>
-    </main>
+    <section id="acknowledgments" class="animate-on-scroll">
+      <h2>Acknowledgments</h2>
+      <p>
+        This work was supported by the National Natural Science Foundation of China
+        (Nos. 72192823, 62177038, and 62522217).
+      </p>
+    </section>
 
     <footer>
-      <div>
-        <strong>PGPO</strong>
-        <span>EMNLP 2026 · Main Conference</span>
-      </div>
       <p>
+        Project page for PGPO · EMNLP 2026 Main Conference ·
         <a href="https://github.com/Shengxiang-Lin/PGPO">GitHub</a>
-        <span>·</span>
-        <a href="https://huggingface.co/Shengxiang-Lin/PGPO">Hugging Face</a>
       </p>
     </footer>
   </div>
@@ -472,65 +347,67 @@ pip install -r requirements.txt</code></pre>
     (function () {
       var root = document.documentElement;
       var btn = document.getElementById('theme-toggle');
+      var SUN = '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4.2" fill="currentColor"/><g stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 2.5v2.2"/><path d="M12 19.3v2.2"/><path d="M2.5 12h2.2"/><path d="M19.3 12h2.2"/><path d="M5.1 5.1l1.6 1.6"/><path d="M17.3 17.3l1.6 1.6"/><path d="M18.9 5.1l-1.6 1.6"/><path d="M6.7 17.3l-1.6 1.6"/></g></svg>';
+      var MOON = '<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>';
 
-      var sun = '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>';
-      var moon = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20.5 15.3A8.5 8.5 0 0 1 8.7 3.5a8.5 8.5 0 1 0 11.8 11.8z"/></svg>';
-
-      function dark() {
+      function isDark() {
         return root.getAttribute('data-theme') === 'dark';
       }
 
-      function paint() {
-        btn.innerHTML = dark() ? sun : moon;
-        btn.setAttribute('aria-label', dark() ? 'Switch to light theme' : 'Switch to dark theme');
+      function syncIcon() {
+        btn.innerHTML = isDark() ? SUN : MOON;
       }
 
       btn.addEventListener('click', function () {
-        if (dark()) {
+        if (isDark()) {
           root.removeAttribute('data-theme');
           localStorage.setItem('pgpo-theme', 'light');
         } else {
           root.setAttribute('data-theme', 'dark');
           localStorage.setItem('pgpo-theme', 'dark');
         }
-        paint();
+        syncIcon();
       });
+      syncIcon();
 
-      paint();
-
-      var copyButtons = document.querySelectorAll('[data-copy-target]');
-      copyButtons.forEach(function (button) {
-        button.addEventListener('click', function () {
-          var target = document.getElementById(button.getAttribute('data-copy-target'));
-          if (!target) return;
-          var text = target.innerText;
-          var original = button.textContent;
-
-          function done() {
-            button.textContent = 'Copied';
-            setTimeout(function () { button.textContent = original; }, 1400);
-          }
-
-          if (navigator.clipboard && navigator.clipboard.writeText) {
-            navigator.clipboard.writeText(text).then(done);
-          }
+      var copyBtn = document.getElementById('copybtn');
+      copyBtn.addEventListener('click', function () {
+        var text = document.getElementById('bibtex-code').innerText;
+        navigator.clipboard.writeText(text).then(function () {
+          var old = copyBtn.textContent;
+          copyBtn.textContent = 'Copied!';
+          setTimeout(function () { copyBtn.textContent = old; }, 1400);
         });
       });
 
-      var nodes = document.querySelectorAll('.reveal');
+      var sections = document.querySelectorAll('.animate-on-scroll');
+      var heads = document.querySelectorAll('h2');
+
       if ('IntersectionObserver' in window) {
-        var observer = new IntersectionObserver(function (entries) {
+        var so = new IntersectionObserver(function (entries) {
           entries.forEach(function (entry) {
             if (entry.isIntersecting) {
-              entry.target.classList.add('visible');
-              observer.unobserve(entry.target);
+              entry.target.classList.add('animated');
+              so.unobserve(entry.target);
             }
           });
-        }, { threshold: 0.08, rootMargin: '0px 0px -40px 0px' });
+        }, { threshold: 0.08, rootMargin: '0px 0px -36px 0px' });
 
-        nodes.forEach(function (node) { observer.observe(node); });
+        sections.forEach(function (s) { so.observe(s); });
+
+        var ho = new IntersectionObserver(function (entries) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting) {
+              entry.target.classList.add('animated');
+              ho.unobserve(entry.target);
+            }
+          });
+        }, { threshold: 0.2 });
+
+        heads.forEach(function (h) { ho.observe(h); });
       } else {
-        nodes.forEach(function (node) { node.classList.add('visible'); });
+        sections.forEach(function (s) { s.classList.add('animated'); });
+        heads.forEach(function (h) { h.classList.add('animated'); });
       }
     })();
   </script>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,43 +1,29 @@
 :root {
-  --accent: #1768e5;
-  --accent-strong: #0b4dbc;
-  --accent-soft: #eaf2ff;
-  --accent-glow: rgba(23, 104, 229, .18);
-
-  --text: #252b35;
-  --text-strong: #121722;
-  --muted: #687383;
+  --accent: #0056d6;
+  --accent-dark: #00369f;
+  --accent-lite: #4a90e2;
+  --grad: linear-gradient(135deg, #00369f 0%, #0056d6 100%);
+  --text: #3a3f45;
+  --muted: #6a737d;
   --bg: #ffffff;
-  --surface: rgba(255, 255, 255, .84);
-  --soft: #f6f8fb;
-  --soft-strong: #eef3f9;
-  --border: #dde3eb;
-  --border-strong: #cbd5e2;
-  --shadow: rgba(24, 50, 87, .10);
-
-  --max: 920px;
-  --radius: 14px;
-  --radius-lg: 20px;
-  --sans: "Manrope", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --mono: "DM Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --soft: #f6f8fa;
+  --card: #ffffff;
+  --border: #e1e4e8;
+  --shadow: rgba(20, 40, 80, .10);
 }
 
 [data-theme="dark"] {
-  --accent: #69a7ff;
-  --accent-strong: #8bbaff;
-  --accent-soft: rgba(54, 126, 229, .14);
-  --accent-glow: rgba(63, 140, 255, .16);
-
-  --text: #cbd4df;
-  --text-strong: #f3f6fa;
-  --muted: #8e9aa9;
-  --bg: #0b1017;
-  --surface: rgba(18, 25, 35, .82);
-  --soft: #111924;
-  --soft-strong: #162130;
-  --border: #273445;
-  --border-strong: #34445a;
-  --shadow: rgba(0, 0, 0, .34);
+  --accent: #58a6ff;
+  --accent-dark: #79b8ff;
+  --accent-lite: #1f6feb;
+  --grad: linear-gradient(135deg, #1f6feb 0%, #388bfd 100%);
+  --text: #c9d1d9;
+  --muted: #8b949e;
+  --bg: #0d1117;
+  --soft: #161b22;
+  --card: #161b22;
+  --border: #30363d;
+  --shadow: rgba(0, 0, 0, .5);
 }
 
 * {
@@ -45,703 +31,335 @@
 }
 
 html {
+  -webkit-text-size-adjust: 100%;
   scroll-behavior: smooth;
-  scroll-padding-top: 90px;
 }
 
 body {
   margin: 0;
+  position: relative;
   color: var(--text);
   background: var(--bg);
-  font-family: var(--sans);
-  font-size: 16px;
-  line-height: 1.72;
-  -webkit-font-smoothing: antialiased;
-  transition: color .25s ease, background-color .25s ease;
+  font-family: "Trebuchet MS", "Segoe UI", Arial, sans-serif;
+  font-size: 17px;
+  line-height: 1.7;
+  transition: background-color .3s ease, color .3s ease;
 }
 
 body::before {
   content: "";
   position: fixed;
   inset: 0;
-  z-index: -3;
+  z-index: -1;
   pointer-events: none;
-  background:
-    radial-gradient(circle at 18% 8%, rgba(38, 119, 236, .08), transparent 28%),
-    radial-gradient(circle at 88% 30%, rgba(121, 93, 231, .06), transparent 26%),
-    linear-gradient(145deg, rgba(240, 247, 255, .45), rgba(255, 255, 255, 0) 48%);
+  background-image:
+    linear-gradient(
+      135deg,
+      rgba(240, 248, 255, .28) 0%,
+      rgba(230, 240, 255, .18) 25%,
+      rgba(245, 250, 255, .22) 50%,
+      rgba(235, 245, 255, .18) 75%,
+      rgba(240, 248, 255, .28) 100%
+    );
+  background-size: 400% 400%;
+  animation: gradientShift 15s ease infinite;
 }
 
 [data-theme="dark"] body::before {
-  background:
-    radial-gradient(circle at 18% 8%, rgba(55, 131, 240, .12), transparent 28%),
-    radial-gradient(circle at 88% 30%, rgba(99, 78, 209, .08), transparent 26%);
+  background-image:
+    linear-gradient(
+      135deg,
+      rgba(13, 17, 23, .30) 0%,
+      rgba(22, 27, 34, .20) 25%,
+      rgba(13, 17, 23, .25) 50%,
+      rgba(22, 27, 34, .20) 75%,
+      rgba(13, 17, 23, .30) 100%
+    );
 }
 
-.ambient {
-  position: fixed;
-  z-index: -2;
-  width: 420px;
-  height: 420px;
-  border-radius: 50%;
-  filter: blur(90px);
-  opacity: .16;
-  pointer-events: none;
-  animation: drift 18s ease-in-out infinite alternate;
+@keyframes gradientShift {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
 }
 
-.ambient-one {
-  top: -180px;
-  left: -150px;
-  background: #5aa2ff;
-}
-
-.ambient-two {
-  right: -180px;
-  top: 36%;
-  background: #8e7cf3;
-  animation-delay: -7s;
-}
-
-@keyframes drift {
-  from { transform: translate3d(0, 0, 0) scale(1); }
-  to { transform: translate3d(35px, 25px, 0) scale(1.08); }
-}
-
-a {
-  color: inherit;
-}
-
-img {
-  display: block;
-  max-width: 100%;
-}
-
-button,
-a {
-  -webkit-tap-highlight-color: transparent;
-}
-
-.page-shell {
-  width: min(calc(100% - 36px), var(--max));
+.wrap {
+  max-width: 820px;
   margin: 0 auto;
+  padding: 34px 20px 64px;
 }
 
-.topbar {
-  position: sticky;
-  top: 14px;
-  z-index: 50;
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 24px;
-  align-items: center;
-  margin-top: 14px;
-  padding: 10px 12px 10px 14px;
-  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--surface) 90%, transparent);
-  box-shadow: 0 10px 30px var(--shadow);
-  backdrop-filter: blur(16px);
-}
-
-.brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 9px;
-  color: var(--text-strong);
-  font-weight: 800;
+a {
+  color: var(--accent);
   text-decoration: none;
 }
 
-.brand-mark {
-  display: grid;
-  width: 29px;
-  height: 29px;
-  place-items: center;
-  border-radius: 9px;
-  color: #fff;
-  background: linear-gradient(135deg, #0d4fb8, #267df5);
-  box-shadow: 0 5px 14px var(--accent-glow);
-  font-size: 13px;
-  font-weight: 800;
+a:not(.btn) {
+  background-image: linear-gradient(90deg, var(--accent-dark), var(--accent));
+  background-repeat: no-repeat;
+  background-position: left bottom;
+  background-size: 0 1.5px;
+  padding-bottom: 1px;
+  transition: background-size .3s cubic-bezier(.4, 0, .2, 1), color .3s ease;
 }
 
-.nav-links {
-  display: flex;
-  justify-content: center;
-  gap: 22px;
-}
-
-.nav-links a {
-  color: var(--muted);
-  font-size: 13px;
-  font-weight: 600;
-  text-decoration: none;
-  transition: color .18s ease;
-}
-
-.nav-links a:hover {
-  color: var(--accent);
-}
-
-.theme-toggle {
-  display: grid;
-  width: 34px;
-  height: 34px;
-  place-items: center;
-  border: 0;
-  border-radius: 50%;
-  color: var(--muted);
-  background: var(--soft);
-  cursor: pointer;
-}
-
-.theme-toggle:hover {
-  color: var(--accent);
-  background: var(--accent-soft);
-}
-
-.theme-toggle svg {
-  width: 16px;
-  height: 16px;
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 1.8;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.hero {
-  padding: 108px 0 50px;
-  text-align: center;
-}
-
-.venue-row {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 8px;
-  margin-bottom: 24px;
-}
-
-.venue {
-  display: inline-flex;
-  align-items: center;
-  min-height: 30px;
-  padding: 5px 12px;
-  border-radius: 999px;
-  color: #fff;
-  background: linear-gradient(135deg, #0b4aa9, #1c74ef);
-  box-shadow: 0 7px 18px var(--accent-glow);
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: .025em;
-}
-
-.venue-soft {
-  border: 1px solid var(--border-strong);
-  color: var(--accent-strong);
-  background: var(--surface);
-  box-shadow: none;
-}
-
-h1,
-h2,
-h3,
-p {
-  text-wrap: pretty;
+a:not(.btn):hover {
+  color: var(--accent-dark);
+  background-size: 100% 1.5px;
 }
 
 h1 {
-  max-width: 900px;
-  margin: 0 auto;
-  color: var(--text-strong);
-  font-size: clamp(2.55rem, 6.3vw, 4.55rem);
-  font-weight: 800;
-  letter-spacing: -.055em;
-  line-height: 1.03;
-}
-
-.title-accent {
-  color: var(--accent);
+  margin: .1em 0 .35em;
+  color: var(--text);
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -.01em;
+  line-height: 1.25;
 }
 
 .subtitle {
-  max-width: 730px;
-  margin: 24px auto 0;
+  margin: 0 0 1em;
   color: var(--muted);
-  font-size: clamp(1.02rem, 1.8vw, 1.18rem);
+  font-size: 1.18rem;
   font-weight: 500;
-  line-height: 1.65;
+  line-height: 1.5;
+}
+
+.venues {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.venue {
+  display: inline-block;
+  padding: 4px 14px;
+  border-radius: 999px;
+  color: #fff;
+  background: var(--grad);
+  box-shadow: 0 2px 8px var(--shadow);
+  font-size: .9rem;
+  font-weight: 600;
+  letter-spacing: .02em;
+}
+
+.venue.secondary {
+  border: 1px solid var(--accent);
+  color: var(--accent-dark);
+  background: var(--soft);
+  box-shadow: none;
 }
 
 .authors {
-  max-width: 840px;
-  margin: 28px auto 0;
-  color: var(--text);
-  font-size: 14px;
-  line-height: 2;
+  margin: 1.15em 0 .4em;
+  line-height: 1.95;
 }
 
-.authors a {
-  color: var(--text-strong);
-  font-weight: 600;
-  text-decoration: none;
-  background-image: linear-gradient(90deg, var(--accent), var(--accent));
-  background-repeat: no-repeat;
-  background-position: left 100%;
-  background-size: 0 1px;
-  transition: color .18s ease, background-size .2s ease;
-}
-
-.authors a:hover {
-  color: var(--accent);
-  background-size: 100% 1px;
+.au {
+  margin-right: .15em;
+  white-space: nowrap;
 }
 
 sup {
-  color: var(--accent);
-  font-size: .68em;
-  font-weight: 700;
+  font-size: .7em;
+  line-height: 0;
 }
 
-.affiliations {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 5px 18px;
-  margin-top: 6px;
+.legend {
+  margin: .2em 0 .4em;
   color: var(--muted);
-  font-size: 12px;
+  font-size: .92rem;
+  line-height: 1.7;
 }
 
-.hero-actions {
+.btns {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
-  gap: 9px;
-  margin-top: 27px;
+  gap: 10px;
+  margin: 1.2em 0 .2em;
 }
 
 .btn {
   display: inline-flex;
-  min-height: 43px;
   align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 9px 15px;
-  border: 1px solid var(--border-strong);
+  gap: .45em;
+  padding: .55em 1.05em;
+  border: 1px solid var(--accent);
   border-radius: 999px;
-  color: var(--text-strong);
-  background: var(--surface);
-  box-shadow: 0 4px 14px rgba(24, 50, 87, .04);
-  font-size: 13px;
-  font-weight: 700;
+  color: var(--accent);
+  background: var(--card);
+  font-size: .95rem;
+  font-weight: 600;
+  line-height: 1;
   text-decoration: none;
-  transition: transform .16s ease, border-color .16s ease, color .16s ease, background .16s ease, box-shadow .16s ease;
-}
-
-.btn svg {
-  width: 16px;
-  height: 16px;
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 1.6;
-  stroke-linecap: round;
-  stroke-linejoin: round;
+  transition: background .15s ease, color .15s ease, box-shadow .15s ease, transform .15s ease;
 }
 
 .btn:hover {
-  border-color: var(--accent);
-  color: var(--accent);
-  box-shadow: 0 8px 20px var(--shadow);
+  color: #fff;
+  background: var(--grad);
+  box-shadow: 0 6px 16px var(--shadow);
   transform: translateY(-1px);
 }
 
-.btn-primary {
-  border-color: var(--accent);
-  color: #fff;
-  background: linear-gradient(135deg, #0c4ead, #1f76ed);
-}
-
-.btn-primary:hover {
-  color: #fff;
-  background: linear-gradient(135deg, #0b459a, #1769d5);
-}
-
-.btn-muted {
+.btn.disabled {
+  border-color: var(--border);
   color: var(--muted);
+  background: var(--soft);
   cursor: default;
 }
 
-.btn-muted:hover {
-  border-color: var(--border-strong);
+.btn.disabled:hover {
   color: var(--muted);
-  box-shadow: 0 4px 14px rgba(24, 50, 87, .04);
+  background: var(--soft);
+  box-shadow: none;
   transform: none;
 }
 
-.hero-figure,
-.paper-figure {
-  margin: 0;
+.ic {
+  width: 1.05em;
+  height: 1.05em;
+  flex: 0 0 auto;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linejoin: round;
 }
 
-.hero-figure {
-  padding: 16px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--surface);
-  box-shadow: 0 18px 50px var(--shadow);
+figure {
+  margin: 2.4em auto .4em;
 }
 
-.hero-figure img,
-.paper-figure img {
+figure img {
+  display: block;
   width: 100%;
   height: auto;
-  border-radius: 10px;
-  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 6px 22px var(--shadow);
+  transition: filter .3s ease;
 }
 
-[data-theme="dark"] .hero-figure img,
-[data-theme="dark"] .paper-figure img {
-  filter: brightness(.86);
+[data-theme="dark"] figure img {
+  filter: brightness(.82);
 }
 
 figcaption {
-  max-width: 760px;
-  margin: 12px auto 0;
+  max-width: 680px;
+  margin: .8em auto 0;
   color: var(--muted);
-  font-size: 12px;
-  line-height: 1.6;
+  font-size: .9rem;
   text-align: center;
 }
 
-.section {
-  padding: 94px 0 8px;
-}
-
-.section + .section {
-  margin-top: 28px;
-}
-
-.section-heading {
-  margin-bottom: 28px;
-}
-
-.section-heading.split {
-  display: grid;
-  grid-template-columns: 1.05fr .95fr;
-  gap: 54px;
-  align-items: end;
-}
-
-.eyebrow {
-  display: inline-block;
-  margin-bottom: 10px;
-  color: var(--accent);
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: .09em;
-  text-transform: uppercase;
+section {
+  margin-top: 0;
 }
 
 h2 {
-  margin: 0;
-  color: var(--text-strong);
-  font-size: clamp(1.85rem, 4vw, 2.65rem);
-  font-weight: 800;
-  letter-spacing: -.035em;
-  line-height: 1.17;
-}
-
-.section-heading > p,
-.section-heading.split > p,
-.section-note {
-  margin: 0;
-  color: var(--muted);
-  font-size: 14px;
-}
-
-.section-heading.split > p {
-  padding-bottom: 4px;
-}
-
-.lead-block {
-  padding: 24px 26px;
-  border: 1px solid var(--border);
-  border-left: 3px solid var(--accent);
-  border-radius: var(--radius);
-  background: var(--soft);
-}
-
-.lead-block p {
-  margin: 0;
-}
-
-.lead-block p + p {
-  margin-top: 14px;
-}
-
-.lead-block strong {
-  color: var(--accent-strong);
-}
-
-.paper-figure {
-  margin-top: 30px;
-  padding: 13px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface);
-  box-shadow: 0 8px 28px rgba(24, 50, 87, .06);
-}
-
-.paper-figure.wide {
-  margin-top: 34px;
-}
-
-.paper-figure.compact {
-  margin-top: 0;
-}
-
-.card-grid {
-  display: grid;
-  gap: 14px;
-  margin-top: 24px;
-}
-
-.card-grid.three {
-  grid-template-columns: repeat(3, 1fr);
-}
-
-.feature-card {
   position: relative;
-  min-height: 180px;
-  padding: 20px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface);
-  transition: transform .18s ease, border-color .18s ease, box-shadow .18s ease;
+  margin: 2.6em 0 .8em;
+  padding-bottom: .3em;
+  color: var(--text);
+  font-size: 1.4rem;
+  line-height: 1.3;
 }
 
-.feature-card::after {
+h2::after {
   content: "";
   position: absolute;
-  right: -44px;
-  bottom: -56px;
-  width: 130px;
-  height: 130px;
-  border-radius: 50%;
-  background: radial-gradient(circle, var(--accent-glow), transparent 67%);
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent-dark), var(--accent), var(--accent-lite));
+  transition: width .8s cubic-bezier(.4, 0, .2, 1);
 }
 
-.feature-card:hover {
-  border-color: var(--border-strong);
-  box-shadow: 0 12px 28px var(--shadow);
-  transform: translateY(-2px);
+h2.animated::after {
+  width: 100%;
 }
 
-.card-index {
-  color: var(--accent);
-  font-family: var(--mono);
-  font-size: 11px;
-}
-
-.feature-card h3,
-.method-flow h3,
-.result-copy h3,
-.resource-card h3,
-.objective-panel h3 {
-  margin: 12px 0 7px;
-  color: var(--text-strong);
-  font-size: 17px;
-  font-weight: 750;
-  line-height: 1.35;
-}
-
-.feature-card p,
-.method-flow p,
-.result-copy p,
-.resource-card p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 13px;
-  line-height: 1.65;
-}
-
-.method-flow {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr auto 1fr;
-  gap: 10px;
-  align-items: stretch;
-}
-
-.method-flow article {
-  display: flex;
-  gap: 13px;
-  padding: 18px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--soft);
-}
-
-.flow-num {
-  display: grid;
-  flex: 0 0 28px;
-  width: 28px;
-  height: 28px;
-  place-items: center;
-  border-radius: 8px;
-  color: #fff;
-  background: linear-gradient(135deg, #0b4aa9, #247df5);
-  font-family: var(--mono);
-  font-size: 11px;
-}
-
-.method-flow h3 {
-  margin-top: 1px;
-}
-
-.flow-arrow {
-  display: grid;
-  place-items: center;
-  color: var(--accent);
-  font-size: 18px;
-}
-
-.objective-panel {
-  display: grid;
-  grid-template-columns: .8fr 1.2fr;
-  gap: 40px;
-  margin-top: 24px;
-  padding: 28px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+h3 {
+  margin: 1.3em 0 .25em;
   color: var(--text);
-  background:
-    radial-gradient(circle at 0 0, var(--accent-glow), transparent 34%),
-    var(--soft);
+  font-size: 1.06rem;
 }
 
-.objective-panel h3 {
-  margin-top: 0;
-  font-size: 24px;
+p {
+  margin: .7em 0;
 }
 
-.reward-list {
-  display: grid;
-  gap: 0;
+.lead {
+  font-size: 1.06rem;
 }
 
-.reward-list > div {
-  display: grid;
-  grid-template-columns: 42px 1fr;
-  gap: 12px;
-  padding: 12px 0;
-  border-top: 1px solid var(--border);
+.contrib {
+  margin: .6em 0 0;
+  padding-left: 1.2em;
 }
 
-.reward-list > div:first-child {
-  padding-top: 0;
-  border-top: 0;
+.contrib li {
+  margin: .45em 0;
 }
 
-.reward-list > div:last-child {
-  padding-bottom: 0;
-}
-
-.reward-list > div > span {
-  color: var(--accent);
-  font-family: var(--mono);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.reward-list p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 13px;
-  line-height: 1.6;
-}
-
-.reward-list strong {
-  color: var(--text-strong);
-}
-
-.metric-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
-}
-
-.metric-card {
-  min-height: 162px;
-  padding: 22px 18px;
+.block {
+  padding: 18px 20px;
   border: 1px solid var(--border);
-  border-radius: var(--radius);
+  border-radius: 8px;
   background: var(--soft);
 }
 
-.metric-card strong {
-  display: block;
-  margin-bottom: 11px;
-  color: var(--accent);
-  font-size: clamp(1.75rem, 4.6vw, 2.45rem);
-  font-weight: 800;
-  letter-spacing: -.04em;
-  line-height: 1;
+.abstract p {
+  margin: 0;
 }
 
-.metric-card span {
-  display: block;
-  color: var(--text-strong);
-  font-size: 13px;
+.finding {
+  margin: 1.15em 0;
+}
+
+.finding h3 .num {
+  margin-right: .35em;
+  color: var(--accent);
   font-weight: 700;
 }
 
-.metric-card small {
-  display: block;
-  margin-top: 6px;
-  color: var(--muted);
-  font-size: 11px;
+strong.k {
+  color: var(--accent-dark);
 }
 
-.result-block {
-  margin-top: 28px;
-}
-
-.result-copy {
-  display: grid;
-  grid-template-columns: .7fr 1.3fr;
-  gap: 38px;
-  align-items: end;
-  margin-bottom: 14px;
-}
-
-.result-copy h3 {
-  margin: 0;
-  font-size: 20px;
-}
-
-.table-wrap {
-  overflow-x: auto;
+.modelset {
+  margin: .6em 0;
+  padding: .7em 14px;
   border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface);
+  border-radius: 8px;
+  background: var(--soft);
+  font-size: .95rem;
+}
+
+.modelset b {
+  color: var(--accent-dark);
+}
+
+.table-scroll {
+  overflow-x: auto;
+  margin-top: 1em;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card);
 }
 
 table {
   width: 100%;
   min-width: 760px;
   border-collapse: collapse;
-  font-family: var(--mono);
-  font-size: 11px;
+  font-size: .84rem;
 }
 
 th,
 td {
-  padding: 12px 11px;
+  padding: 10px 9px;
   border-bottom: 1px solid var(--border);
   text-align: center;
   white-space: nowrap;
@@ -750,15 +368,12 @@ td {
 thead th {
   color: var(--muted);
   background: var(--soft);
-  font-size: 10px;
-  font-weight: 500;
-  letter-spacing: .025em;
-  text-transform: uppercase;
+  font-size: .76rem;
+  font-weight: 600;
 }
 
 thead small {
-  font-size: 8px;
-  letter-spacing: 0;
+  font-size: .7rem;
 }
 
 tbody th,
@@ -767,378 +382,168 @@ tbody td:nth-child(2) {
 }
 
 tbody th {
-  color: var(--text-strong);
-  font-weight: 500;
+  font-weight: 600;
 }
 
-.highlight-row {
-  color: var(--accent-strong);
-  background: var(--accent-soft);
+.accent-row {
+  color: var(--accent-dark);
+  background: rgba(0, 86, 214, .06);
 }
 
-tbody tr:last-child td {
-  border-bottom: 0;
+[data-theme="dark"] .accent-row {
+  background: rgba(88, 166, 255, .08);
 }
 
-.viz-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 14px;
-  margin-top: 18px;
+.reslist {
+  margin: .7em 0;
+  padding-left: 1.2em;
 }
 
-.resource-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
+.reslist li {
+  margin: .32em 0;
 }
 
-.resource-card {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 12px;
-  align-items: center;
-  padding: 18px;
+pre {
+  margin: .8em 0;
+  overflow-x: auto;
+  padding: 16px 18px;
   border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface);
-  text-decoration: none;
-  transition: border-color .18s ease, transform .18s ease, box-shadow .18s ease;
+  border-radius: 8px;
+  color: var(--text);
+  background: var(--soft);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: .88rem;
+  line-height: 1.65;
 }
 
-.resource-card:hover {
-  border-color: var(--accent);
-  box-shadow: 0 10px 26px var(--shadow);
-  transform: translateY(-2px);
-}
-
-.resource-icon {
-  display: grid;
-  width: 34px;
-  height: 34px;
-  place-items: center;
-  border-radius: 10px;
-  color: var(--accent);
-  background: var(--accent-soft);
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 500;
-}
-
-.resource-card h3 {
-  margin: 0 0 3px;
-  font-size: 14px;
-}
-
-.resource-card p {
-  font-size: 11px;
-}
-
-.resource-arrow {
-  color: var(--muted);
-}
-
-.quickstart,
-.bibtex-card {
-  margin-top: 16px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: #101722;
-}
-
-.quickstart-head,
-.bibtex-head {
+.bibhead {
   display: flex;
   justify-content: space-between;
   gap: 16px;
   align-items: center;
-  padding: 10px 13px;
-  border-bottom: 1px solid #253143;
-  color: #8fa0b5;
-  background: #151e2a;
-  font-family: var(--mono);
-  font-size: 10px;
-}
-
-.copy-btn {
-  padding: 5px 9px;
-  border: 1px solid #34455b;
-  border-radius: 7px;
-  color: #bdc9d8;
-  background: #1c2735;
-  font: 500 10px var(--sans);
-  cursor: pointer;
-}
-
-.copy-btn:hover {
-  color: #fff;
-  border-color: #58718f;
-}
-
-pre {
-  margin: 0;
-  overflow-x: auto;
-  padding: 18px;
-  color: #dbe5f2;
-  background: #101722;
-  font-family: var(--mono);
-  font-size: 11px;
-  line-height: 1.75;
-}
-
-.faq-list {
-  display: grid;
-  gap: 9px;
-}
-
-details {
-  overflow: hidden;
+  margin-bottom: -1px;
+  padding: .65em .8em;
   border: 1px solid var(--border);
-  border-radius: var(--radius);
+  border-bottom: 0;
+  border-radius: 8px 8px 0 0;
+  color: var(--muted);
   background: var(--soft);
+  font-size: .86rem;
 }
 
-details[open] {
-  background: var(--surface);
-}
-
-summary {
-  position: relative;
-  padding: 16px 42px 16px 18px;
-  color: var(--text-strong);
-  font-size: 13px;
-  font-weight: 700;
-  cursor: pointer;
-  list-style: none;
-}
-
-summary::-webkit-details-marker {
-  display: none;
-}
-
-summary::after {
-  content: "+";
-  position: absolute;
-  top: 50%;
-  right: 17px;
-  color: var(--accent);
-  font-family: var(--mono);
-  font-size: 18px;
-  transform: translateY(-50%);
-}
-
-details[open] summary::after {
-  content: "−";
-}
-
-details > div {
-  padding: 0 18px 16px;
-}
-
-details p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 13px;
-}
-
-.bibtex-card {
+.bibhead + pre {
   margin-top: 0;
+  border-radius: 0 0 8px 8px;
 }
 
-.ack {
+.copy {
+  padding: .45em .75em;
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--card);
+  font: 600 .82rem "Trebuchet MS", "Segoe UI", Arial, sans-serif;
+  cursor: pointer;
+}
+
+.copy:hover {
+  color: #fff;
+  background: var(--grad);
+}
+
+.theme-toggle {
+  position: fixed;
+  top: 18px;
+  right: 20px;
+  z-index: 30;
   display: grid;
-  grid-template-columns: 145px 1fr;
-  gap: 24px;
-  margin-top: 17px;
-  padding: 17px 0;
-  border-top: 1px solid var(--border);
-}
-
-.ack strong {
-  color: var(--text-strong);
-  font-size: 12px;
-}
-
-.ack p {
-  margin: 0;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 50%;
   color: var(--muted);
-  font-size: 12px;
+  background: var(--card);
+  box-shadow: 0 4px 14px var(--shadow);
+  cursor: pointer;
+}
+
+.theme-toggle:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.theme-toggle svg {
+  width: 18px;
+  height: 18px;
+}
+
+.animate-on-scroll {
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity .45s ease, transform .45s ease;
+}
+
+.animate-on-scroll.animated {
+  opacity: 1;
+  transform: none;
 }
 
 footer {
-  display: flex;
-  justify-content: space-between;
-  gap: 30px;
-  align-items: flex-end;
-  margin-top: 100px;
-  padding: 26px 0 36px;
+  margin-top: 3.4em;
+  padding-top: 1.1em;
   border-top: 1px solid var(--border);
   color: var(--muted);
-  font-size: 11px;
+  font-size: .88rem;
 }
 
-footer > div {
-  display: grid;
-  gap: 3px;
-}
-
-footer strong {
-  color: var(--text-strong);
-  font-size: 13px;
-}
-
-footer p {
-  margin: 0;
-}
-
-footer a {
-  color: var(--muted);
-  text-decoration: none;
-}
-
-footer a:hover {
-  color: var(--accent);
-}
-
-.reveal {
-  opacity: 0;
-  transform: translateY(14px);
-  transition: opacity .55s ease, transform .55s cubic-bezier(.2, .7, .2, 1);
-}
-
-.reveal.visible {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-@media (max-width: 760px) {
-  .topbar {
-    grid-template-columns: auto 1fr auto;
-  }
-
-  .nav-links {
-    display: none;
-  }
-
-  .hero {
-    padding-top: 78px;
-  }
-
-  .section {
-    padding-top: 72px;
-  }
-
-  .section-heading.split,
-  .result-copy,
-  .objective-panel {
-    grid-template-columns: 1fr;
-    gap: 18px;
-  }
-
-  .method-flow {
-    grid-template-columns: 1fr;
-  }
-
-  .flow-arrow {
-    height: 20px;
-    transform: rotate(90deg);
-  }
-
-  .card-grid.three,
-  .metric-grid,
-  .resource-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .feature-card,
-  .metric-card {
-    min-height: auto;
-  }
-
-  .viz-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .ack {
-    grid-template-columns: 1fr;
-    gap: 7px;
+@media (max-width: 900px) {
+  .theme-toggle {
+    position: absolute;
   }
 }
 
-@media (max-width: 520px) {
-  .page-shell {
-    width: min(calc(100% - 24px), var(--max));
+@media (max-width: 600px) {
+  body {
+    font-size: 16px;
   }
 
-  .topbar {
-    top: 8px;
-    margin-top: 8px;
-    padding: 8px 9px 8px 11px;
+  .wrap {
+    padding: 24px 16px 46px;
   }
 
   h1 {
-    font-size: clamp(2.25rem, 11.5vw, 3.25rem);
+    padding-right: 44px;
+    font-size: 1.72rem;
   }
 
   .subtitle {
-    font-size: .98rem;
+    font-size: 1.05rem;
   }
 
   .authors {
-    font-size: 13px;
+    line-height: 1.85;
   }
 
-  .affiliations {
-    display: grid;
-    gap: 2px;
-  }
-
-  .hero-actions {
-    align-items: stretch;
+  .btns {
+    gap: 8px;
   }
 
   .btn {
-    flex: 1 1 135px;
+    font-size: .9rem;
   }
 
-  .btn-muted {
-    flex-basis: 100%;
+  figure {
+    margin-top: 1.9em;
   }
 
-  .hero-figure {
-    padding: 8px;
-    border-radius: 12px;
+  h2 {
+    margin-top: 2.3em;
   }
 
-  .lead-block,
-  .feature-card,
-  .metric-card,
-  .resource-card,
-  .objective-panel {
-    padding: 17px;
-  }
-
-  .paper-figure {
-    padding: 7px;
-  }
-
-  .section {
-    padding-top: 62px;
-  }
-
-  pre {
-    font-size: 9.5px;
-  }
-
-  footer {
-    display: block;
-    text-align: center;
-  }
-
-  footer > div {
-    justify-items: center;
-    margin-bottom: 8px;
+  .bibhead {
+    align-items: flex-start;
+    flex-direction: column;
   }
 }
 
@@ -1147,11 +552,11 @@ footer a:hover {
     scroll-behavior: auto;
   }
 
-  .ambient {
+  body::before {
     animation: none;
   }
 
-  .reveal {
+  .animate-on-scroll {
     opacity: 1;
     transform: none;
     transition: none;


### PR DESCRIPTION
## What changed
- removes the oversized landing-page hero and floating navigation
- switches to a compact ~820px academic reading column
- uses restrained ~2rem title sizing, left-aligned authors/affiliations, venue pills, and compact resource buttons
- adopts simple section headings with animated gradient rules, light content blocks, modest figure cards, and a fixed theme toggle
- reorganizes the page into the same reading rhythm as the reference: header → figure → TL;DR → abstract → method → findings → resources → BibTeX

## Scope
Only `docs/index.html` and `docs/style.css` are changed.